### PR TITLE
workflows: switch to non-on-prem version of e2e

### DIFF
--- a/.github/workflows/call-integration-tests.yaml
+++ b/.github/workflows/call-integration-tests.yaml
@@ -81,6 +81,7 @@
           with:
             repository: calyptia/cloud-e2e
             token: ${{ secrets.github-token }}
+            ref: "v1.1.0"
 
         - name: Log in to the Container registry
           uses: docker/login-action@v2


### PR DESCRIPTION
Switchover to non-on-prem version of e2e testing temporarily just to satisfy any CI testing whilst we update for #22 