### PR TITLE
copied over call-integrations-tests.yaml from cloud-e2e

### DIFF
--- a/.github/workflows/call-integration-tests.yaml
+++ b/.github/workflows/call-integration-tests.yaml
@@ -7,11 +7,12 @@
           type: string
           required: false
           default: latest
-          description: standard release version of the calyptia cli to use.
+          description: release version of the calyptia cli to use.
         cli-image:
           type: string
           required: false
-          description: intended to be used with CLI PRs
+          default: ghcr.io/calyptia/cli:main
+          description: Deprecated - will be removed.
         cloud-image:
           type: string
           required: false
@@ -37,11 +38,39 @@
           required: false
           default: ghcr.io/calyptia/core-operator/sync-to-cloud:latest
           description: docker image of calyptia/core-operator
+        core-operator-crd-manifest:
+          type: string
+          required: false
+          description: Optional name of artefact to download containing operator manifests. Must be uploaded prior to calling this workflow.
+        frontend-image:
+          type: string
+          required: false
+          default: ghcr.io/calyptia/frontend:main
+          description: docker image of calyptia/frontend
+        lua-sandbox-image:
+          type: string
+          required: false
+          default: ghcr.io/calyptia/cloud-lua-sandbox:latest
+          description: docker image of calyptia/cloud-lua-sandbox
+        fluentd-version:
+          type: string
+          required: false
+          default: v1.2-debian
+          description: fluentd image version to use from fluent/fluentd dockerhub.
+        ref:
+          description: The commit, tag or branch of this repository to checkout
+          type: string
+          required: false
+          default: refs/heads/main
+        calyptia-tests:
+          description: Path to tests to be executed
+          type: string
+          required: false
         runner:
           description: The runner to use for tests.
           type: string
           required: false
-          default: actuated-4cpu-16gb
+          default: actuated-arm64
       secrets:
         registry-username:
           description: ci username to use for login into container registry
@@ -49,14 +78,26 @@
         registry-password:
           description: ci password to use for login into container registry
           required: true
+        aws-access-key-id:
+          description: Deprecated - will be removed.
+          required: false
+        aws-secret-access-key:
+          description: Deprecated - will be removed.
+          required: false
         google-access-key:
           description: The GCP access key.
           required: true
         github-token:
           description: The Github token for checking out the code.
-          required: true
+          required: false # TODO: switch over once done
   jobs:
     run-integration-tests:
+      # permissions:
+      #   # Needed for the debug SSH connection to Actuated
+      #   id-token: write
+      #   contents: read
+      #   actions: read
+      #   packages: read
       strategy:
         fail-fast: false
         matrix:
@@ -68,17 +109,15 @@
             - 'v1.23.17'
       runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
       env:
-        # No versions for cloud image yet: https://app.asana.com/0/1205042382663691/1205262887299330/f
-        CALYPTIA_CLOUD_IMAGE: ${{ inputs.cloud-image }}
         AWS_EC2_METADATA_DISABLED: true
-        FLUENTD_VERSION: v1.2-debian
+        FLUENTD_VERSION: ${{ inputs.fluentd-version }}
         CALYPTIA_CLI_VERSION: ${{ inputs.cli-version }}
+        CALYPTIA_CLOUD_IMAGE: ${{ inputs.cloud-image }}
         CALYPTIA_CORE_IMAGE: ${{ inputs.core-image }}
         CALYPTIA_CORE_OPERATOR_IMAGE: ${{ inputs.core-operator-image }}
         CALYPTIA_CORE_OPERATOR_FROM_CLOUD_IMAGE: ${{ inputs.core-operator-from-cloud-image }}
         CALYPTIA_CORE_OPERATOR_TO_CLOUD_IMAGE: ${{ inputs.core-operator-to-cloud-image }}
-        # May be empty
-        CALYPTIA_CLI_IMAGE: ${{ inputs.cli-image }}
+        CALYPTIA_CORE_OPERATOR_CRD: ${{ (inputs.core-operator-crd-manifest != '' && 'override/crd.yaml') || '' }}
       steps:
         - name: Install dependencies
           run: |
@@ -87,14 +126,41 @@
           shell: bash
 
         - name: Set up Actuated mirror
-          if: ${{ contains(inputs.runner, 'actuated') }}
+          if: contains(inputs.runner, 'actuated')
           uses: self-actuated/hub-mirror@master
+
+        # - name: Prep SSH access just in case
+        #   # https://github.com/mxschmitt/action-tmate#detached-mode
+        #   uses: mxschmitt/action-tmate@v3
+        #   with:
+        #     detached: true
 
         - name: Checkout the Code
           uses: actions/checkout@v4
           with:
             repository: calyptia/cloud-e2e
-            token: ${{ secrets.github-token }}
+            ref: ${{ inputs.ref }}
+            # TODO: Swap over once everyone passing valid token
+            # token: ${{ secrets.github-token }}
+            token: ${{ secrets.registry-password }}
+
+        - name: Verify selected tests exist
+          if: inputs.calyptia-tests != ''
+          run: |
+            if [[ -d "./bats/${{ inputs.calyptia-tests }}" ]]; then
+              echo "Found test set: ${{ inputs.calyptia-tests }}"
+            else
+              echo "Unable to find test set: ${{ inputs.calyptia-tests }}"
+              exit 1
+            fi
+          shell: bash
+
+        - name: Download crd manifest
+          if: inputs.core-operator-crd-manifest != ''
+          uses: actions/download-artifact@v3
+          with:
+            name: ${{ inputs.core-operator-crd-manifest }}
+            path: override
 
         - name: Log in to the Container registry
           uses: docker/login-action@v3
@@ -113,6 +179,7 @@
             wait: 300s
 
         - name: Install KIND
+          if: contains(inputs.runner, 'actuated')
           uses: helm/kind-action@v1.8.0
           with:
             install_only: true
@@ -176,23 +243,12 @@
             kind load docker-image $CALYPTIA_CORE_OPERATOR_FROM_CLOUD_IMAGE
           shell: bash
 
-        - if: inputs.cli-image != ''
-          run: |
-            docker pull $CALYPTIA_CLI_IMAGE
-            kind load docker-image $CALYPTIA_CLI_IMAGE
-          shell: bash
-
         - name: Set up Cloud SDK
           uses: google-github-actions/setup-gcloud@v1
 
         - name: Run bats tests
           run: |
-            if [[ -n "$CALYPTIA_CLI_IMAGE" ]]; then
-              echo "Using CLI image: $CALYPTIA_CLI_IMAGE"
-              export CALYPTIA_CLI_IMAGE_TAG=${CALYPTIA_CLI_IMAGE_TAG:-${CALYPTIA_CLI_IMAGE##*:}}
-              export CALYPTIA_CLI_IMAGE=${CALYPTIA_CLI_IMAGE%:*}
-            fi
-            ./run-bats.sh
+            ./run-bats.sh ${{ inputs.calyptia-tests }}
           shell: bash
           timeout-minutes: 30
           env:

--- a/.github/workflows/call-integration-tests.yaml
+++ b/.github/workflows/call-integration-tests.yaml
@@ -70,7 +70,7 @@
           description: The runner to use for tests.
           type: string
           required: false
-          default: actuated-arm64
+          default: actuated-4cpu-16gb
       secrets:
         registry-username:
           description: ci username to use for login into container registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,16 @@ jobs:
     # uses: calyptia/cloud-e2e/.github/workflows/call-integration-tests.yaml@main
     # Instead we have to replicate the same workflow locally
     uses: ./.github/workflows/call-integration-tests.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        testset:
+          - operator-install
+          - operator
+          - cluster_logging
+          - core
+          - fleet
+          - vm-images
     with:
       cli-version: v${{ needs.ci-get-metadata.outputs.cli-version }}
       cloud-image: ghcr.io/calyptia/cloud:${{ needs.ci-get-metadata.outputs.cloud-version }}
@@ -27,6 +37,7 @@ jobs:
       core-operator-image: ghcr.io/calyptia/core-operator:${{ needs.ci-get-metadata.outputs.core-operator-version }}
       core-operator-from-cloud-image: ghcr.io/calyptia/core-operator/sync-from-cloud:${{ needs.ci-get-metadata.outputs.core-operator-version }}
       core-operator-to-cloud-image: ghcr.io/calyptia/core-operator/sync-to-cloud:${{ needs.ci-get-metadata.outputs.core-operator-version }}
+      calyptia-tests: "${{ matrix.testset }}/"
     secrets:
       registry-username: ${{ secrets.CI_USERNAME }}
       registry-password: ${{ secrets.CI_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,6 @@ jobs:
         testset:
           - operator-install
           - operator
-          - cluster_logging
-          - core
-          - fleet
-          - vm-images
     with:
       cli-version: v${{ needs.ci-get-metadata.outputs.cli-version }}
       cloud-image: ghcr.io/calyptia/cloud:${{ needs.ci-get-metadata.outputs.cloud-version }}


### PR DESCRIPTION
When CLI workflow invokes e2e it calls all possible tests we have which not efficient. Plus tests are failing due to various reasons.