### PR TITLE
workflows: add CVE and SBOM generation

### DIFF
--- a/.github/workflows/call-generate-reports.yaml
+++ b/.github/workflows/call-generate-reports.yaml
@@ -34,9 +34,6 @@
                   run: |
                     sudo apt-get update
                     sudo apt-get install -y jq
-                    curl -sSfL https://raw.githubusercontent.com/docker/sbom-cli-plugin/main/install.sh | sh -s --
-                    curl https://github.com/docker/scan-cli-plugin/releases/latest/download/docker-scan_linux_amd64 -L -s -S -o ~/.docker/cli-plugins/docker-scan
-                    chmod +x ~/.docker/cli-plugins/docker-scan
                   shell: bash
 
                 - name: Checkout

--- a/.github/workflows/call-generate-reports.yaml
+++ b/.github/workflows/call-generate-reports.yaml
@@ -34,6 +34,9 @@
                   run: |
                     sudo apt-get update
                     sudo apt-get install -y jq
+                    curl -sSfL https://raw.githubusercontent.com/docker/sbom-cli-plugin/main/install.sh | sh -s --
+                    curl https://github.com/docker/scan-cli-plugin/releases/latest/download/docker-scan_linux_amd64 -L -s -S -o ~/.docker/cli-plugins/docker-scan
+                    chmod +x ~/.docker/cli-plugins/docker-scan
                   shell: bash
 
                 - name: Checkout

--- a/.github/workflows/call-generate-reports.yaml
+++ b/.github/workflows/call-generate-reports.yaml
@@ -53,8 +53,6 @@
                   shell: bash
                   env:
                     OUTPUT_DIR: reports
-                    TAR_NAME: ${{ github.ref_name }}-reports.tar.gz
-                    ZIP_NAME: ${{ github.ref_name }}-reports.zip
 
                 - uses: actions/upload-artifact@v3
                   with:

--- a/.github/workflows/call-generate-reports.yaml
+++ b/.github/workflows/call-generate-reports.yaml
@@ -1,0 +1,68 @@
+---
+    name: Reusable workflow for generating reports
+    on:
+        workflow_call:
+            inputs:
+                ref:
+                    description: The commit, tag or branch of this repository to checkout
+                    type: string
+                    required: false
+                    default: refs/heads/main
+            secrets:
+                registry-username:
+                    description: ci username to use for login into container registry
+                    required: true
+                registry-password:
+                    description: ci password to use for login into container registry
+                    required: true
+                github-token:
+                    description: The Github token for checking out the code.
+                    required: true
+            outputs:
+                artefact-name:
+                    description: The name of the uploaded artefact with the reports in.
+                    value: reports
+    jobs:
+        ci-generate-reports:
+            name: Generate SBOM and CVE reports
+            permissions:
+                contents: read
+                packages: read
+            runs-on: ubuntu-latest
+            steps:
+                - name: Add dependencies
+                  run: |
+                    sudo apt-get update
+                    sudo apt-get install -y jq
+                  shell: bash
+
+                - name: Checkout
+                  uses: actions/checkout@v4
+                  with:
+                    ref: ${{ inputs.ref }}
+
+                - name: Login to GitHub Container Registry
+                  uses: docker/login-action@v3
+                  with:
+                    registry: ghcr.io
+                    username: ${{ secrets.registry-username }}
+                    password: ${{ secrets.registry-password }}
+
+                - name: Generate reports
+                  run: ./scripts/generate-reports.sh
+                  shell: bash
+                  env:
+                    OUTPUT_DIR: reports
+                    TAR_NAME: ${{ github.ref_name }}-reports.tar.gz
+                    ZIP_NAME: ${{ github.ref_name }}-reports.zip
+
+                - uses: actions/upload-artifact@v3
+                  with:
+                    name: reports
+                    path: |
+                        component-config.json
+                        ./scripts/generate-reports.sh
+                        reports/
+                        *-reports.*
+                    if-no-files-found: error
+                    retention-days: 5

--- a/.github/workflows/call-integration-tests.yaml
+++ b/.github/workflows/call-integration-tests.yaml
@@ -167,7 +167,7 @@
       uses: ./.github/workflows/get-versions.yaml
 
     run-integration-tests-kind:
-      if: inputs.k8s-distribution == 'kind'
+      if: inputs.k8s-distribution == 'kind' && !(contains(inputs.runner, 'mac') || contains(inputs.runner, 'windows'))
       needs:
         - verify-inputs
         - get-versions
@@ -362,7 +362,7 @@
           shell: bash
 
     run-integration-tests-openshift:
-      if: inputs.k8s-distribution == 'openshift'
+      if: inputs.k8s-distribution == 'openshift' && !(contains(inputs.runner, 'mac') || contains(inputs.runner, 'windows'))
       runs-on: ${{ inputs.runner }}
       needs:
         - verify-inputs
@@ -555,3 +555,27 @@
           shell: bash
           env:
             VM_NAME: ${{ steps.get-vm-name.outputs.VM_NAME }}
+
+    run-integration-tests-windows:
+      if: contains(inputs.runner, 'windows')
+      runs-on: ${{ inputs.runner }}
+      needs:
+        - verify-inputs
+        - get-versions
+      steps:
+        - name: Placeholder
+          run: echo 'TBD'
+
+    run-integration-tests-macos:
+      # Covers both standard Github and Cirruslabs
+      # runner: macos-latest <- intel
+      # runner: ghcr.io/cirruslabs/macos-ventura-xcode:14 <- apple
+      if: contains(inputs.runner, 'macos')
+      runs-on: ${{ inputs.runner }}
+      needs:
+        - verify-inputs
+        - get-versions
+      steps:
+        - name: Placeholder
+          run: echo 'TBD'
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       github-token: ${{ secrets.CI_PAT }}
 
   ci-e2e-tests-openshift:
+    if: contains(github.event.pull_request.labels.*.name, 'openshift-build')
     needs:
       - ci-get-metadata
     # We cannot run this from a public repo as the cloud-e2e repo is private so even though it shares workflows with the Calyptia org,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,13 @@ jobs:
       # Replace with playground key after: https://app.asana.com/0/1205042382663691/1205231066738712/f
       google-access-key: ${{ secrets.GCP_SA_KEY }}
       github-token: ${{ secrets.CI_PAT }}
+
+  ci-generate-reports:
+    name: Generate SBOM and CVE reports for release
+    uses: ./.github/workflows/call-generate-reports.yaml
+    with:
+      ref: ${{ github.ref }}
+    secrets:
+      registry-username: ${{ secrets.CI_USERNAME }}
+      registry-password: ${{ secrets.CI_PAT }}
+      github-token: ${{ secrets.CI_PAT }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,16 +10,33 @@ jobs:
         with:
             ref: ${{ github.ref }}
 
+    ci-generate-reports:
+      name: Generate SBOM and CVE reports for release
+      uses: ./.github/workflows/call-generate-reports.yaml
+      with:
+          ref: ${{ github.ref }}
+      secrets:
+        registry-username: ${{ secrets.CI_USERNAME }}
+        registry-password: ${{ secrets.CI_PAT }}
+        github-token: ${{ secrets.CI_PAT }}
+
     ci-release:
         name: Create official release
         runs-on: ubuntu-latest
         needs:
             - ci-get-metadata
+            - ci-generate-reports
         permissions:
             contents: write
         steps:
         - name: Checkout
           uses: actions/checkout@v4
+
+        - name: Download reports
+          uses: actions/download-artifact@v3
+          with:
+            name: ${{ needs.ci-generate-reports.outputs.artefact-name }}
+            path: reports/
 
         - name: Create release for tag
           uses: softprops/action-gh-release@v1
@@ -36,6 +53,7 @@ jobs:
             fail_on_unmatched_files: false
             files: |
                 *.json
+                reports/*.json
             generate_release_notes: false
 
     ci-update-self-hosted:
@@ -136,15 +154,24 @@ jobs:
         - name: Inject latest version
           run: echo "${{ github.ref_name }}" > ./latest-tag.txt
 
+        - name: Download reports
+          uses: actions/download-artifact@v3
+          with:
+            name: ${{ needs.ci-generate-reports.outputs.artefact-name }}
+            path: reports/
+
         - name: Update any versions
           run: |
             if [[ -x ./scripts/update-version.sh ]]; then
-                echo "Updating versions to "
-                ./scripts/update-version.sh
+                echo "Updating versions to $NEW_VERSION"
+                ./scripts/update-version.sh "$NEW_VERSION"
             else
                 echo "Skipping as no executable ./scripts/update-version.sh found"
             fi
           shell: bash
+          env:
+            NEW_VERSION: ${{ github.ref_name }}
+            REPORTS_DIR: reports
 
         - name: Generate PR
           id: cpr

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -124,6 +124,8 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: none
+        needs:
+          - ci-generate-reports
         steps:
         - name: Determine major version value from tag
           id: get-branch

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,8 +52,7 @@ jobs:
                 - LUA Sandbox: ${{ needs.ci-get-metadata.outputs.lua-sandbox-version }}
             fail_on_unmatched_files: false
             files: |
-                *.json
-                reports/*.json
+                **/*.json
             generate_release_notes: false
 
     ci-update-self-hosted:
@@ -160,7 +159,7 @@ jobs:
           uses: actions/download-artifact@v3
           with:
             name: ${{ needs.ci-generate-reports.outputs.artefact-name }}
-            path: reports/
+            path: /tmp/
 
         - name: Update any versions
           run: |
@@ -173,7 +172,7 @@ jobs:
           shell: bash
           env:
             NEW_VERSION: ${{ github.ref_name }}
-            REPORTS_DIR: reports
+            REPORTS_DIR: /tmp/reports
 
         - name: Generate PR
           id: cpr

--- a/scripts/generate-reports.sh
+++ b/scripts/generate-reports.sh
@@ -46,9 +46,9 @@ do
   output_file=${image//\//-}
   output_file=${output_file//:/-}
   echo "Generating sbom for $image to $OUTPUT_DIR/$output_file"
-  syft docker:"$image" --output syft-json="$OUTPUT_DIR"/"$output_file.syft.json",spdx-json="$OUTPUT_DIR"/"$output_file.spdx.json",cyclonedx-json="$OUTPUT_DIR"/"$output_file.cyclonedx.json"
-  grype docker:"$image" --by-cve --output json > "$OUTPUT_DIR"/"$output_file.cves.json"
-  grype docker:"$image" --by-cve --output cyclonedx-json > "$OUTPUT_DIR"/"$output_file.cves.cyclonedx.json"
+  syft docker:"$image" --output "syft-json=${OUTPUT_DIR}/${output_file}.syft.json,spdx-json=${OUTPUT_DIR}/${output_file}.spdx.json,cyclonedx-json=${OUTPUT_DIR}/${output_file}.cyclonedx.json"
+  grype docker:"$image" --by-cve --output json > "${OUTPUT_DIR}"/"${output_file}.cves.json"
+  grype docker:"$image" --by-cve --output cyclonedx-json > "${OUTPUT_DIR}"/"${output_file}.cves.cyclonedx.json"
 done
 
 tar -czf "$TAR_NAME" -C "$OUTPUT_DIR" .

--- a/scripts/generate-reports.sh
+++ b/scripts/generate-reports.sh
@@ -10,6 +10,11 @@ if ! command -v docker &> /dev/null; then
     echo "ERROR: missing docker command, please install"
     exit 1
 fi
+
+docker --version
+docker sbom --version
+docker scan --version
+
 if ! command -v jq &> /dev/null; then
     echo "ERROR: missing jq command, please install"
     exit 1

--- a/scripts/generate-reports.sh
+++ b/scripts/generate-reports.sh
@@ -40,8 +40,8 @@ do
   output_file=${image//\//-}
   output_file=${output_file//:/-}
   echo "Generating sbom for $image to $OUTPUT_DIR/$output_file"
-  docker sbom "$image" --output "$OUTPUT_DIR"/"$output_file.spdx.json" --format spdx-json
-  docker sbom "$image" --output "$OUTPUT_DIR"/"$output_file.cyclonedx.json" --format cyclonedx-json
+  docker sbom "$image" --format spdx-json > "$OUTPUT_DIR"/"$output_file.spdx.json"
+  docker sbom "$image" --format cyclonedx-json > "$OUTPUT_DIR"/"$output_file.cyclonedx.json"
   docker scan "$image" --json --group-issues > "$OUTPUT_DIR"/"$output_file.scan.json"
 done
 

--- a/scripts/generate-reports.sh
+++ b/scripts/generate-reports.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -eu
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+OUTPUT_DIR=${OUTPUT_DIR:-$(mktemp -d)}
+TAR_NAME=${TAR_NAME:-/tmp/calyptia-sboms.tgz}
+ZIP_NAME=${ZIP_NAME:-/tmp/calyptia-sboms.zip}
+
+if ! command -v docker &> /dev/null; then
+    echo "ERROR: missing docker command, please install"
+    exit 1
+fi
+if ! command -v jq &> /dev/null; then
+    echo "ERROR: missing jq command, please install"
+    exit 1
+fi
+
+CORE_FB_VERSION=${CORE_FB_VERSION:-$(jq -r .versions.core_fluent_bit "$SCRIPT_DIR/../component-config.json")}
+FRONTEND_VERSION=${FRONTEND_VERSION:-$(jq -r .versions.frontend "$SCRIPT_DIR/../component-config.json")}
+LUASANDBOX_VERSION=${LUASANDBOX_VERSION:-$(jq -r .versions.lua_sandbox "$SCRIPT_DIR/../component-config.json")}
+CORE_OPERATOR_VERSION=${CORE_OPERATOR_VERSION:-$(jq -r .versions.core_operator "$SCRIPT_DIR/../component-config.json")}
+HOT_RELOAD_VERSION=${HOT_RELOAD_VERSION:-$(jq -r .versions.configmap_reload "$SCRIPT_DIR/../component-config.json")}
+INGEST_CHECKS_VERSION=${INGEST_CHECKS_VERSION:-$(jq -r .versions.core_sidecar_ingest_check "$SCRIPT_DIR/../component-config.json")}
+
+declare -a images=("ghcr.io/calyptia/configmap-reload:$HOT_RELOAD_VERSION"
+"ghcr.io/calyptia/core/calyptia-fluent-bit:$CORE_FB_VERSION"
+"ghcr.io/calyptia/core/ingest-check:$INGEST_CHECKS_VERSION"
+"ghcr.io/calyptia/core-operator:$CORE_OPERATOR_VERSION"
+"ghcr.io/calyptia/core-operator/sync-to-cloud:$CORE_OPERATOR_VERSION"
+"ghcr.io/calyptia/core-operator/sync-from-cloud:$CORE_OPERATOR_VERSION"
+"ghcr.io/calyptia/frontend:$FRONTEND_VERSION"
+"ghcr.io/calyptia/cloud-lua-sandbox:$LUASANDBOX_VERSION"
+)
+
+rm -rf "${OUTPUT_DIR:?}/*"
+mkdir -p "$OUTPUT_DIR"
+
+for image in "${images[@]}"
+do
+  output_file=${image//\//-}
+  output_file=${output_file//:/-}
+  echo "Generating sbom for $image to $OUTPUT_DIR/$output_file"
+  docker sbom "$image" --output "$OUTPUT_DIR"/"$output_file.spdx.json" --format spdx-json
+  docker sbom "$image" --output "$OUTPUT_DIR"/"$output_file.cyclonedx.json" --format cyclonedx-json
+  docker scan "$image" --json --group-issues > "$OUTPUT_DIR"/"$output_file.scan.json"
+done
+
+tar -czf "$TAR_NAME" -C "$OUTPUT_DIR" .
+zip -jr "$ZIP_NAME" "$OUTPUT_DIR"

--- a/scripts/generate-reports.sh
+++ b/scripts/generate-reports.sh
@@ -46,7 +46,8 @@ do
   output_file=${image//\//-}
   output_file=${output_file//:/-}
   echo "Generating sbom for $image to $OUTPUT_DIR/$output_file"
-  syft docker:"$image" --output "syft-json=${OUTPUT_DIR}/${output_file}.syft.json,spdx-json=${OUTPUT_DIR}/${output_file}.spdx.json,cyclonedx-json=${OUTPUT_DIR}/${output_file}.cyclonedx.json"
+  # shellcheck disable=SC2140
+  syft docker:"$image" --output "syft-json=${OUTPUT_DIR}/${output_file}.syft.json","spdx-json=${OUTPUT_DIR}/${output_file}.spdx.json","cyclonedx-json=${OUTPUT_DIR}/${output_file}.cyclonedx.json"
   grype docker:"$image" --by-cve --output json > "${OUTPUT_DIR}"/"${output_file}.cves.json"
   grype docker:"$image" --by-cve --output cyclonedx-json > "${OUTPUT_DIR}"/"${output_file}.cves.cyclonedx.json"
 done

--- a/scripts/generate-reports.sh
+++ b/scripts/generate-reports.sh
@@ -47,9 +47,11 @@ do
   output_file=${output_file//:/-}
   echo "Generating sbom for $image to $OUTPUT_DIR/$output_file"
   # shellcheck disable=SC2140
-  syft docker:"$image" --output "syft-json=${OUTPUT_DIR}/${output_file}.syft.json","spdx-json=${OUTPUT_DIR}/${output_file}.spdx.json","cyclonedx-json=${OUTPUT_DIR}/${output_file}.cyclonedx.json"
-  grype docker:"$image" --by-cve --output json > "${OUTPUT_DIR}"/"${output_file}.cves.json"
-  grype docker:"$image" --by-cve --output cyclonedx-json > "${OUTPUT_DIR}"/"${output_file}.cves.cyclonedx.json"
+  syft docker:"$image" --output syft-json > "${OUTPUT_DIR}/${output_file}.syft.json"
+  syft docker:"$image" --output spdx-json > "${OUTPUT_DIR}/${output_file}.spdx.json"
+  syft docker:"$image" --output cyclonedx-json > "${OUTPUT_DIR}/${output_file}.cyclonedx.json"
+  grype docker:"$image" --add-cpes-if-none --by-cve --output json > "${OUTPUT_DIR}"/"${output_file}.cves.json"
+  grype docker:"$image" --add-cpes-if-none --by-cve --output cyclonedx-json > "${OUTPUT_DIR}"/"${output_file}.cves.cyclonedx.json"
 done
 
 tar -czf "$TAR_NAME" -C "$OUTPUT_DIR" .


### PR DESCRIPTION
Generate CVEs and SBOM reports automatically via `syft` and `grype` tooling: `docker scan/sbom/scout` has various subscription or install requirements.

For releases these will be automatically added to the documentation as well thanks to https://github.com/calyptia/core-docs/pull/32