### PR TITLE
fleet: add end to end tests for fluent-bit for non-linux operating systems.

### DIFF
--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -105,7 +105,8 @@
             export CALYPTIA_CLOUD_URL=http://127.0.0.1:8080
             export CALYPTIA_CLOUD_TOKEN=eyJQcm9qZWN0SUQiOiJmb29iYXIifQ.faketoken
             (cd fleet-mock-api;
-              go run main.go > mock.log &
+              # step RUNNER_TRACKING_ID="" in an attempt to avoid process cleanup
+              env RUNNER_TRACKING_ID="" go run main.go > mock.log &
               echo $! > ../MOCK.PID
             )
             export PATH="${PATH}":${{ steps.calyptia-cli.outputs.path }}
@@ -191,7 +192,8 @@
             export CALYPTIA_CLOUD_URL=http://127.0.0.1:8080
             export CALYPTIA_CLOUD_TOKEN=eyJQcm9qZWN0SUQiOiJmb29iYXIifQ.faketoken
             (cd fleet-mock-api;
-              go run main.go > mock.log &
+              # step RUNNER_TRACKING_ID="" in an attempt to avoid process cleanup
+              env RUNNER_TRACKING_ID="" go run main.go > mock.log &
               echo $! > ../MOCK.PID
             )
             export PATH="${PATH}":${{ steps.calyptia-cli.outputs.path }}

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -8,10 +8,6 @@ on:
         required: false
         default: 1.11.0
         description: release version of the calyptia cli to use.
-      calyptia-lts-version:
-        type: string
-        required: false
-        description: release version of calyptia fluent-bit lts to use.
       calyptia-package-artefact:
         type: string
         required: false
@@ -93,15 +89,6 @@ jobs:
             DP=$(echo $DP | sed 's/\([A-Za-z]\)\:/\l\1/' | sed 's/\\/\//g')
             DP="/${DP}"
             mv "${DP}/"*.zip /tmp/calyptia-fluent-bit.zip
-      - name: Download and Install Calyptia Fluent-Bit LTS Package
-        if: ${{ inputs.calyptia-cli-version != '' }}
-        shell: bash
-        run: |
-          URL="${{ inputs.calyptia-lts-repo }}/windows"
-          URL="${URL}/${{ inputs.calyptia-lts-version }}"
-          URL="${URL}/calyptia-fluent-bit"
-          URL="${URL}-${{ inputs.calyptia-lts-version }}-win64.zip"
-          curl "${URL}" --output /tmp/calyptia-fluent-bit.zip
       - name: Unzip Calyptia Package
         shell: bash
         id: pkginstall

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -92,10 +92,7 @@ jobs:
             DP="${{ steps.download.outputs.download-path }}"
             DP=$(echo $DP | sed 's/\([A-Za-z]\)\:/\l\1/' | sed 's/\\/\//g')
             DP="/${DP}"
-            ls -alF "${DP}"
-            # unzip the one zip in download path which should be the calyptia
-            # package zip.
-            mv "${DP}/*.zip" /tmp/calyptia-fluent-bit.zip
+            mv "${DP}/"*.zip /tmp/calyptia-fluent-bit.zip
       - name: Download and Install Calyptia Fluent-Bit LTS Package
         if: ${{ inputs.calyptia-cli-version != '' }}
         shell: bash

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -106,7 +106,8 @@
             export CALYPTIA_CLOUD_TOKEN=eyJQcm9qZWN0SUQiOiJmb29iYXIifQ.faketoken
             (cd fleet-mock-api;
               # step RUNNER_TRACKING_ID="" in an attempt to avoid process cleanup
-              env RUNNER_TRACKING_ID="" go run main.go > mock.log &
+              go build ./
+              env RUNNER_TRACKING_ID="" ./fleet-mock-api > mock.log &
               echo $! > ../MOCK.PID
             )
             export PATH="${PATH}":${{ steps.calyptia-cli.outputs.path }}
@@ -193,7 +194,8 @@
             export CALYPTIA_CLOUD_TOKEN=eyJQcm9qZWN0SUQiOiJmb29iYXIifQ.faketoken
             (cd fleet-mock-api;
               # step RUNNER_TRACKING_ID="" in an attempt to avoid process cleanup
-              env RUNNER_TRACKING_ID="" go run main.go > mock.log &
+              go build ./
+              env RUNNER_TRACKING_ID="" ./fleet-mock-api > mock.log &
               echo $! > ../MOCK.PID
             )
             export PATH="${PATH}":${{ steps.calyptia-cli.outputs.path }}

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -66,7 +66,7 @@
         # missing: lsof, parallel, bc
         - name: Install dependencies
           run: |
-            choco install netcat httpie jq python3 coreutils
+            choco install netcat httpie
           shell: bash
         - name: Download and Install Calyptia Fluent-Bit LTS Package
           id: pkginstall
@@ -112,7 +112,7 @@
           run: |
             # missing: time (reserved shell keyword)
             brew update
-            brew install netcat lsof parallel httpie jq bc coreutils
+            brew install netcat lsof parallel httpie bc coreutils
           shell: bash
         - name: Set Architecture Package according to runner
           id: pkgarch

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -105,13 +105,12 @@
             export CALYPTIA_CLOUD_URL=http://127.0.0.1:8080
             export CALYPTIA_CLOUD_TOKEN=eyJQcm9qZWN0SUQiOiJmb29iYXIifQ.faketoken
             (cd fleet-mock-api;
-              go run main.go > /dev/null &
+              go run main.go > mock.log &
               echo $! > ../MOCK.PID
             )
-            ls -alF "${BATS_BIN_PATH}"
-            file "${BATS_BIN_PATH}/bats"
-            echo "PATH=${PATH}"
             export PATH="${PATH}":${{ steps.calyptia-cli.outputs.path }}
+            sleep 3
+            cat mock.log
             ./run-bats.sh ${{ inputs.calyptia-tests }}
             kill -9 "$(cat MOCK.PID)"
           shell: bash
@@ -192,10 +191,12 @@
             export CALYPTIA_CLOUD_URL=http://127.0.0.1:8080
             export CALYPTIA_CLOUD_TOKEN=eyJQcm9qZWN0SUQiOiJmb29iYXIifQ.faketoken
             (cd fleet-mock-api;
-              go run main.go > /dev/null &
+              go run main.go > mock.log &
               echo $! > ../MOCK.PID
             )
             export PATH="${PATH}":${{ steps.calyptia-cli.outputs.path }}
+            sleep 3
+            cat mock.log
             ./run-bats.sh ${{ inputs.calyptia-tests }}
             kill -9 "$(cat MOCK.PID)"
           # shell: bash

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -85,11 +85,19 @@
             repository: calyptia/cloud-e2e
             ref: ${{ inputs.ref }}
             token: ${{ secrets.github-token }}
+        - name: Checkout the Code for the Mock Server
+          uses: actions/checkout@v4
+          with:
+            repository: calyptia/fleet-mock-api
+            # must also be updated when the initial version is accepted.
+            ref: initial-version
+            path: fleet-mock-api
+            token: ${{ secrets.github-token }}
         - name: Run bats tests
           run: |
             export CALYPTIA_CLOUD_URL=http://127.0.0.1:8080
             export CALYPTIA_CLOUD_TOKEN=eyJQcm9qZWN0SUQiOiJmb29iYXIifQ.faketoken
-            (cd mock-fleet-api;
+            (cd fleet-mock-api;
               go run main.go > /dev/null &
               echo $! > ../MOCK.PID
             )
@@ -111,7 +119,7 @@
         - name: Install dependencies
           run: |
             # missing: time (reserved shell keyword)
-            brew update
+            # brew update
             brew install netcat lsof parallel httpie bc coreutils
           shell: bash
         - name: Set Architecture Package according to runner
@@ -147,13 +155,13 @@
             repository: calyptia/fleet-mock-api
             # must also be updated when the initial version is accepted.
             ref: initial-version
-            path: mock-fleet-api
+            path: fleet-mock-api
             token: ${{ secrets.github-token }}
         - name: Run bats tests
           run: |
             export CALYPTIA_CLOUD_URL=http://127.0.0.1:8080
             export CALYPTIA_CLOUD_TOKEN=eyJQcm9qZWN0SUQiOiJmb29iYXIifQ.faketoken
-            (cd mock-fleet-api;
+            (cd fleet-mock-api;
               go run main.go > /dev/null &
               echo $! > ../MOCK.PID
             )

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -88,7 +88,7 @@
             URL="${URL}/cli_${{ inputs.calyptia-cli-version }}_windows_amd64.tar.gz"
             curl "${URL}" --output /tmp/calyptia-cli.tar.gz
             mkdir -p /tmp/calyptia-cli/
-            tar zxvf -C /tmp/calyptia-cli/
+            tar zxvf /tmp/calyptia-cli.tar.gz -C /tmp/calyptia-cli/
             echo "path=/tmp/calyptia-cli" >> "${GITHUB_OUTPUT}"
         - name: Checkout the Code
           uses: actions/checkout@v4
@@ -167,7 +167,7 @@
             URL="${URL}_${{ steps.pkgarch.outputs.arch }}.tar.gz"
             curl "${URL}" --output /tmp/calyptia-cli.tar.gz
             mkdir -p /tmp/calyptia-cli/
-            tar zxvf -C /tmp/calyptia-cli/
+            tar zxvf /tmp/calyptia-cli.tar.gz -C /tmp/calyptia-cli/
             echo "path=/tmp/calyptia-cli" >> "${GITHUB_OUTPUT}"
         - name: Checkout the Code
           uses: actions/checkout@v4

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -10,8 +10,12 @@ on:
         description: release version of the calyptia cli to use.
       calyptia-lts-version:
         type: string
-        required: true
+        required: false
         description: release version of calyptia fluent-bit lts to use.
+      calyptia-package-artefact:
+        type: string
+        required: false
+        description: package artefact for calyptia fluent-bit
       ref:
         description: The commit, tag or branch of this repository to checkout
         type: string
@@ -31,6 +35,7 @@ on:
         type: string
         required: false
         default: https://calyptia-lts-staging-standard.s3.amazonaws.com
+
     secrets:
       CALYPTIA_CLOUD_URL:
         description: The URL to the cloud instance used for testing.
@@ -72,24 +77,48 @@ jobs:
         uses: mig4/setup-bats@v1
         with:
           bats-version: 1.10.0
+      - name: Download Fluent-Bit Binary from Artefact
+        id: download
+        if: ${{ inputs.calyptia-package-artefact }}
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.calyptia-package-artefact }}
+      - name: Transform Download Path to MSYS2
+        if: ${{ inputs.calyptia-package-artefact }}
+        shell: bash
+        run: |
+          # transform download-path into msys2 equivalent
+            DP="${{ steps.download.outputs.download-path }}"
+            DP=$(echo $DP | sed 's/\([A-Za-z]\)\:/\l\1/' | sed 's/\\/\//g')
+            DP="/${DP}"
+            # unzip the one zip in download path which should be the calyptia
+            # package zip.
+            mv "${DP}/*.zip" /tmp/calyptia-fluent-bit.zip
       - name: Download and Install Calyptia Fluent-Bit LTS Package
-        id: pkginstall
+        if: ${{ inputs.calyptia-cli-version != '' }}
         shell: bash
         run: |
           URL="${{ inputs.calyptia-lts-repo }}/windows"
           URL="${URL}/${{ inputs.calyptia-lts-version }}"
-          URL="${URL}/calyptia-fluent-bit-${{ inputs.calyptia-lts-version }}-win64.zip"
+          URL="${URL}/calyptia-fluent-bit"
+          URL="${URL}-${{ inputs.calyptia-lts-version }}-win64.zip"
           curl "${URL}" --output calyptia-fluent-bit-win64.zip
+      - name: Unzip Calyptia Package
+        shell: bash
+        id: pkginstall
+        run: |
           unzip calyptia-fluent-bit-win64.zip -d /tmp
           mv /tmp/calyptia-fluent-bit-* /tmp/calyptia-fluent-bit
-          echo "bin=/tmp/calyptia-fluent-bit/bin/calyptia-fluent-bit" >> "${GITHUB_OUTPUT}"
+          echo "bin=/tmp/calyptia-fluent-bit/bin/calyptia-fluent-bit" \
+            >> "${GITHUB_OUTPUT}"
       - name: Install Calyptia CLI
         id: calyptia-cli
         shell: bash
         run: |
           URL="https://github.com/calyptia/cli/releases/download"
           URL="${URL}/v${{ inputs.calyptia-cli-version }}"
-          URL="${URL}/cli_${{ inputs.calyptia-cli-version }}_windows_amd64.tar.gz"
+          URL="${URL}/cli_${{ inputs.calyptia-cli-version }}"
+          URL="${URL}_windows_amd64.tar.gz"
           echo "Calyptia CLI URL: ${URL}"
           curl -L "${URL}" --output /tmp/calyptia-cli.tar.gz
           mkdir -p /tmp/calyptia-cli/

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -110,7 +110,7 @@
             )
             export PATH="${PATH}":${{ steps.calyptia-cli.outputs.path }}
             sleep 3
-            cat mock.log
+            cat fleet-mock-api/mock.log
             ./run-bats.sh ${{ inputs.calyptia-tests }}
             kill -9 "$(cat MOCK.PID)"
           shell: bash
@@ -196,7 +196,7 @@
             )
             export PATH="${PATH}":${{ steps.calyptia-cli.outputs.path }}
             sleep 3
-            cat mock.log
+            cat fleet-mock-api/mock.log
             ./run-bats.sh ${{ inputs.calyptia-tests }}
             kill -9 "$(cat MOCK.PID)"
           # shell: bash

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -48,19 +48,10 @@
           run: echo "Checks complete"
           shell: bash
 
-    setup-bats:
-      runs-on: ${{ inputs.runner }}
-      steps:
-        - name: Setup BATS
-          uses: mig4/setup-bats@v1
-          with:
-            bats-version: 1.10.0
-
     run-integration-tests-windows:
       if: contains(inputs.runner, 'windows')
       runs-on: ${{ inputs.runner }}
       needs:
-        - setup-bats
         - verify-inputs
       steps:
         # missing: lsof, parallel, bc
@@ -68,6 +59,10 @@
           run: |
             choco install netcat httpie
           shell: bash
+        - name: Install Bats
+          uses: mig4/setup-bats@v1
+          with:
+            bats-version: 1.10.0
         - name: Download and Install Calyptia Fluent-Bit LTS Package
           id: pkginstall
           shell: bash
@@ -113,6 +108,9 @@
               go run main.go > /dev/null &
               echo $! > ../MOCK.PID
             )
+            ls -alF "${BATS_BIN_PATH}"
+            file "${BATS_BIN_PATH}/bats"
+            echo "PATH=${PATH}"
             export PATH="${PATH}":${{ steps.calyptia-cli.outputs.path }}
             ./run-bats.sh ${{ inputs.calyptia-tests }}
             kill -9 "$(cat MOCK.PID)"
@@ -126,7 +124,6 @@
       if: contains(inputs.runner, 'macos')
       runs-on: ${{ inputs.runner }}
       needs:
-        - setup-bats
         - verify-inputs
       steps:
         - name: Install dependencies
@@ -135,6 +132,10 @@
             # brew update
             brew install netcat lsof parallel httpie bc coreutils
           shell: bash
+        - name: Install Bats
+          uses: mig4/setup-bats@v1
+          with:
+            bats-version: 1.10.0
         - name: Set Architecture Package according to runner
           id: pkgarch
           run: |

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -66,7 +66,6 @@
         # missing: lsof, parallel, bc
         - name: Install dependencies
           run: |
-            brew update
             choco install netcat httpie jq python3 coreutils
           shell: bash
         - name: Download and Install Calyptia Fluent-Bit LTS Package
@@ -112,7 +111,8 @@
         - name: Install dependencies
           run: |
             # missing: time (reserved shell keyword)
-            choco install netcat lsof parallel httpie jq bc python3 coreutils
+            brew update
+            brew install netcat lsof parallel httpie jq bc python3 coreutils
           shell: bash
         - name: Set Architecture Package according to runner
           id: pkgarch

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -31,22 +31,24 @@ on:
         type: string
         required: false
         default: https://calyptia-lts-staging-standard.s3.amazonaws.com
-
-    secrets:
-      CALYPTIA_CLOUD_URL:
-        description: The URL to the cloud instance used for testing.
+      calyptia-cloud-url:
+        description: The cloud URL to use
+        type: string
         required: true
-      CALYPTIA_CLOUD_TOKEN:
+    secrets:
+      calyptia-cloud-token:
         description: |
           The token used to authenticate to the cloud instance used for
           testing.
         required: true
       github-token:
         description: The Github token for checking out the code.
-        # TODO: switch over once done
-        required: false
+        required: true
 env:
   CALYPTIA_CLI_VERSION: ${{ inputs.calyptia-cli-version }}
+  CALYPTIA_CLOUD_URL: ${{ inputs.calyptia-cloud-url }}
+  CALYPTIA_CLOUD_TOKEN: ${{ secrets.CALYPTIA_CLOUD_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.github-token }}
 
 jobs:
   verify-inputs:
@@ -125,8 +127,6 @@ jobs:
         env:
           TEST_UID: ${{ github.repository }}-${{ github.run_id }}-${{ strategy.job-index }}
           FLUENTBIT_BIN: ${{ steps.pkginstall.outputs.bin }}
-          CALYPTIA_CLOUD_URL: ${{ secrets.CALYPTIA_CLOUD_URL }}
-          CALYPTIA_CLOUD_TOKEN: ${{ secrets.CALYPTIA_CLOUD_TOKEN }}
 
   run-integration-tests-macos:
     if: contains(inputs.runner, 'macos')
@@ -191,10 +191,7 @@ jobs:
         run: |
           export PATH="${PATH}":${{ steps.calyptia-cli.outputs.path }}
           ./run-bats.sh ${{ inputs.calyptia-tests }}
-        # shell: bash
         timeout-minutes: 30
         env:
-          CALYPTIA_CLOUD_URL: ${{ secrets.CALYPTIA_CLOUD_URL }}
-          CALYPTIA_CLOUD_TOKEN: ${{ secrets.CALYPTIA_CLOUD_TOKEN }}
           TEST_UID: ${{ github.repository }}-${{ github.run_id }}-${{ strategy.job-index }}
           FLUENTBIT_BIN: ${{ steps.pkginstall.outputs.bin }}

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -112,8 +112,7 @@
         - name: Install dependencies
           run: |
             # missing: time (reserved shell keyword)
-            brew update
-            brew install netcat lsof parallel httpie jq bc python3 coreutils
+            choco install netcat lsof parallel httpie jq bc python3 coreutils
           shell: bash
         - name: Set Architecture Package according to runner
           id: pkgarch

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -83,6 +83,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.calyptia-package-artefact }}
+          path: /tmp/fluent-bit
       - name: Transform Download Path to MSYS2
         if: ${{ inputs.calyptia-package-artefact }}
         shell: bash

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -86,6 +86,7 @@
             URL="https://github.com/calyptia/cli/releases/download"
             URL="${URL}/v${{ inputs.calyptia-cli-version }}"
             URL="${URL}/cli_${{ inputs.calyptia-cli-version }}_windows_amd64.tar.gz"
+            echo "Calyptia CLI URL: ${URL}"
             curl "${URL}" --output /tmp/calyptia-cli.tar.gz
             mkdir -p /tmp/calyptia-cli/
             tar zxvf /tmp/calyptia-cli.tar.gz -C /tmp/calyptia-cli/
@@ -166,6 +167,7 @@
             URL="${URL}/cli_${{ inputs.calyptia-cli-version }}_darwin"
             URL="${URL}_${{ steps.pkgarch.outputs.arch }}.tar.gz"
             curl "${URL}" --output /tmp/calyptia-cli.tar.gz
+            echo "Calyptia CLI URL: ${URL}"
             mkdir -p /tmp/calyptia-cli/
             tar zxvf /tmp/calyptia-cli.tar.gz -C /tmp/calyptia-cli/
             echo "path=/tmp/calyptia-cli" >> "${GITHUB_OUTPUT}"
@@ -184,6 +186,7 @@
             path: fleet-mock-api
             token: ${{ secrets.github-token }}
         - name: Run bats tests
+          shell: bash
           run: |
             export CALYPTIA_CLOUD_URL=http://127.0.0.1:8080
             export CALYPTIA_CLOUD_TOKEN=eyJQcm9qZWN0SUQiOiJmb29iYXIifQ.faketoken

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -12,6 +12,7 @@ on:
         type: string
         required: false
         description: package artefact for calyptia fluent-bit
+        default: ""
       ref:
         description: The commit, tag or branch of this repository to checkout
         type: string
@@ -31,6 +32,11 @@ on:
         type: string
         required: false
         default: https://calyptia-lts-staging-standard.s3.amazonaws.com
+      calyptia-lts-version:
+        description: The version of Calyptia Fluent Bit to take from the repo.
+        type: string
+        required: false
+        default: ""
       calyptia-cloud-url:
         description: The cloud URL to use
         type: string
@@ -47,7 +53,7 @@ on:
 env:
   CALYPTIA_CLI_VERSION: ${{ inputs.calyptia-cli-version }}
   CALYPTIA_CLOUD_URL: ${{ inputs.calyptia-cloud-url }}
-  CALYPTIA_CLOUD_TOKEN: ${{ secrets.CALYPTIA_CLOUD_TOKEN }}
+  CALYPTIA_CLOUD_TOKEN: ${{ secrets.calyptia-cloud-token }}
   GITHUB_TOKEN: ${{ secrets.github-token }}
 
 jobs:
@@ -56,6 +62,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
+      - name: Fail if missing version and package
+        if: inputs.calyptia-lts-version == '' && inputs.calyptia-package-artefact == ''
+        run: exit 1
+        shell: bash
+
       - name: Success
         run: echo "Checks complete"
         shell: bash
@@ -71,10 +82,13 @@ jobs:
         run: |
           choco install netcat httpie
         shell: bash
+
       - name: Install Bats
         uses: mig4/setup-bats@v1
         with:
           bats-version: 1.10.0
+
+      # TODO: install from LTS repo
       - name: Download Fluent-Bit Binary from Artefact
         id: download
         if: ${{ inputs.calyptia-package-artefact }}
@@ -82,16 +96,19 @@ jobs:
         with:
           name: ${{ inputs.calyptia-package-artefact }}
           path: /tmp/fluent-bit
+
       - name: Transform Download Path to MSYS2
         if: ${{ inputs.calyptia-package-artefact }}
         shell: bash
+        # transform download-path into msys2 equivalent
         run: |
-          # transform download-path into msys2 equivalent
             DP="${{ steps.download.outputs.download-path }}"
             DP=$(echo $DP | sed 's/\([A-Za-z]\)\:/\l\1/' | sed 's/\\/\//g')
             DP="/${DP}"
             mv "${DP}/"*.zip /tmp/calyptia-fluent-bit.zip
+
       - name: Unzip Calyptia Package
+        if: ${{ inputs.calyptia-package-artefact }}
         shell: bash
         id: pkginstall
         run: |
@@ -99,6 +116,7 @@ jobs:
           mv /tmp/calyptia-fluent-bit-* /tmp/calyptia-fluent-bit
           echo "bin=/tmp/calyptia-fluent-bit/bin/calyptia-fluent-bit" \
             >> "${GITHUB_OUTPUT}"
+
       - name: Install Calyptia CLI
         id: calyptia-cli
         shell: bash
@@ -112,12 +130,14 @@ jobs:
           mkdir -p /tmp/calyptia-cli/
           tar zxvf /tmp/calyptia-cli.tar.gz -C /tmp/calyptia-cli/
           echo "path=/tmp/calyptia-cli" >> "${GITHUB_OUTPUT}"
+
       - name: Checkout the Code
         uses: actions/checkout@v4
         with:
           repository: calyptia/cloud-e2e
           ref: ${{ inputs.ref }}
           token: ${{ secrets.github-token }}
+
       - name: Run bats tests
         run: |
           export PATH="${PATH}":${{ steps.calyptia-cli.outputs.path }}
@@ -156,8 +176,10 @@ jobs:
             echo "brand=intel" >> "${GITHUB_OUTPUT}"
             echo "arch=amd64" >> "${GITHUB_OUTPUT}"
           fi
+      # TODO: add package usage
       - name: Download and Install Calyptia Fluent-Bit LTS Package
         id: pkginstall
+        if: inputs.calyptia-lts-version != ''
         shell: bash
         run: |
           URL="${{ inputs.calyptia-lts-repo }}/macos"

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -3,10 +3,10 @@
   on:
     workflow_call:
       inputs:
-        cli-version:
+        calyptia-cli-version:
           type: string
           required: false
-          default: latest
+          default: 1.11.0
           description: release version of the calyptia cli to use.
         calyptia-lts-version:
           type: string
@@ -36,7 +36,7 @@
           description: The Github token for checking out the code.
           required: false # TODO: switch over once done
   env:
-    CALYPTIA_CLI_VERSION: ${{ inputs.cli-version }}
+    CALYPTIA_CLI_VERSION: ${{ inputs.calyptia-cli-version }}
 
   jobs:
     verify-inputs:
@@ -79,6 +79,17 @@
             unzip calyptia-fluent-bit-win64.zip -d /tmp
             mv /tmp/calyptia-fluent-bit-* /tmp/calyptia-fluent-bit
             echo "bin=/tmp/calyptia-fluent-bit/bin/calyptia-fluent-bit" >> "${GITHUB_OUTPUT}"
+        - name: Install Calyptia CLI
+          id: calyptia-cli
+          shell: bash
+          run: |
+            URL="https://github.com/calyptia/cli/releases/download"
+            URL="${URL}/v${{ inputs.calyptia-cli-version }}"
+            URL="${URL}/cli_${{ inputs.calyptia-cli-version }}_windows_amd64.tar.gz"
+            curl "${URL}" --output /tmp/calyptia-cli.tar.gz
+            mkdir -p /tmp/calyptia-cli/
+            tar zxvf -C /tmp/calyptia-cli/
+            echo "path=/tmp/calyptia-cli" >> "${GITHUB_OUTPUT}"
         - name: Checkout the Code
           uses: actions/checkout@v4
           with:
@@ -101,6 +112,7 @@
               go run main.go > /dev/null &
               echo $! > ../MOCK.PID
             )
+            export PATH="${PATH}":${{ steps.calyptia-cli.outputs.bin }}
             ./run-bats.sh ${{ inputs.calyptia-tests }}
             kill -9 "$(cat MOCK.PID)"
           shell: bash
@@ -128,9 +140,11 @@
             echo -n "Runner architecture: "
             uname -m
             if [ "$(uname -m)" == "arm64" ]; then
-              echo "arch=apple" >> "${GITHUB_OUTPUT}"
+              echo "brand=apple" >> "${GITHUB_OUTPUT}"
+              echo "arch=arm64" >> "${GITHUB_OUTPUT}"
             else
-              echo "arch=intel" >> "${GITHUB_OUTPUT}"
+              echo "brand=intel" >> "${GITHUB_OUTPUT}"
+              echo "arch=amd64" >> "${GITHUB_OUTPUT}"
             fi
         - name: Download and Install Calyptia Fluent-Bit LTS Package
           id: pkginstall
@@ -138,11 +152,23 @@
           run: |
             URL="${{ inputs.calyptia-lts-repo }}/macos"
             URL="${URL}/${{ inputs.calyptia-lts-version }}"
-            URL="${URL}/calyptia-fluent-bit-${{ inputs.calyptia-lts-version }}-${{ steps.pkgarch.outputs.arch }}.pkg"
+            URL="${URL}/calyptia-fluent-bit-${{ inputs.calyptia-lts-version }}-${{ steps.pkgarch.outputs.brand }}.pkg"
             wget "${URL}" -O calyptia-fluent-bit.pkg
             installer -pkg calyptia-fluent-bit.pkg -target CurrentUserHomeDirectory
             # pkgutil --lsbom io.fluentbit.calyptia-fluent-bit.binary --volume $HOME
             echo "bin=${HOME}/./usr/local/bin/calyptia-fluent-bit" >> "${GITHUB_OUTPUT}"
+        - name: Install Calyptia CLI
+          id: calyptia-cli
+          shell: bash
+          run: |
+            URL="https://github.com/calyptia/cli/releases/download"
+            URL="${URL}/v${{ inputs.calyptia-cli-version }}"
+            URL="${URL}/cli_${{ inputs.calyptia-cli-version }}_darwin"
+            URL="${URL}_${{ steps.pkgarch.outputs.arch }}.tar.gz"
+            curl "${URL}" --output /tmp/calyptia-cli.tar.gz
+            mkdir -p /tmp/calyptia-cli/
+            tar zxvf -C /tmp/calyptia-cli/
+            echo "path=/tmp/calyptia-cli" >> "${GITHUB_OUTPUT}"
         - name: Checkout the Code
           uses: actions/checkout@v4
           with:
@@ -165,6 +191,7 @@
               go run main.go > /dev/null &
               echo $! > ../MOCK.PID
             )
+            export PATH="${PATH}":${{ steps.calyptia-cli.outputs.bin }}
             ./run-bats.sh ${{ inputs.calyptia-tests }}
             kill -9 "$(cat MOCK.PID)"
           # shell: bash

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -113,7 +113,7 @@
               go run main.go > /dev/null &
               echo $! > ../MOCK.PID
             )
-            export PATH="${PATH}":${{ steps.calyptia-cli.outputs.bin }}
+            export PATH="${PATH}":${{ steps.calyptia-cli.outputs.path }}
             ./run-bats.sh ${{ inputs.calyptia-tests }}
             kill -9 "$(cat MOCK.PID)"
           shell: bash
@@ -194,7 +194,7 @@
               go run main.go > /dev/null &
               echo $! > ../MOCK.PID
             )
-            export PATH="${PATH}":${{ steps.calyptia-cli.outputs.bin }}
+            export PATH="${PATH}":${{ steps.calyptia-cli.outputs.path }}
             ./run-bats.sh ${{ inputs.calyptia-tests }}
             kill -9 "$(cat MOCK.PID)"
           # shell: bash

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -101,12 +101,12 @@ jobs:
           URL="${URL}/${{ inputs.calyptia-lts-version }}"
           URL="${URL}/calyptia-fluent-bit"
           URL="${URL}-${{ inputs.calyptia-lts-version }}-win64.zip"
-          curl "${URL}" --output calyptia-fluent-bit.zip
+          curl "${URL}" --output /tmp/calyptia-fluent-bit.zip
       - name: Unzip Calyptia Package
         shell: bash
         id: pkginstall
         run: |
-          unzip calyptia-fluent-bit.zip -d /tmp
+          unzip /tmp/calyptia-fluent-bit.zip -d /tmp
           mv /tmp/calyptia-fluent-bit-* /tmp/calyptia-fluent-bit
           echo "bin=/tmp/calyptia-fluent-bit/bin/calyptia-fluent-bit" \
             >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -80,7 +80,7 @@ jobs:
       # missing: lsof, parallel, bc
       - name: Install dependencies
         run: |
-          choco install netcat httpie
+          choco install netcat httpie kubectl
         shell: bash
 
       - name: Install Bats
@@ -88,7 +88,8 @@ jobs:
         with:
           bats-version: 1.10.0
 
-      # TODO: install from LTS repo
+      # TODO: install from LTS repo: https://github.com/marketplace/actions/engineerd-configurator
+
       - name: Download Fluent-Bit Binary from Artefact
         id: download
         if: ${{ inputs.calyptia-package-artefact }}
@@ -114,8 +115,7 @@ jobs:
         run: |
           unzip /tmp/calyptia-fluent-bit.zip -d /tmp
           mv /tmp/calyptia-fluent-bit-* /tmp/calyptia-fluent-bit
-          echo "bin=/tmp/calyptia-fluent-bit/bin/calyptia-fluent-bit" \
-            >> "${GITHUB_OUTPUT}"
+          echo "bin=/tmp/calyptia-fluent-bit/bin/calyptia-fluent-bit" >> "${GITHUB_OUTPUT}"
 
       - name: Install Calyptia CLI
         id: calyptia-cli
@@ -146,7 +146,7 @@ jobs:
         timeout-minutes: 30
         env:
           TEST_UID: ${{ github.repository }}-${{ github.run_id }}-${{ strategy.job-index }}
-          FLUENTBIT_BIN: ${{ steps.pkginstall.outputs.bin }}
+          FLUENTBIT_BIN: /tmp/calyptia-fluent-bit/bin/calyptia-fluent-bit
 
   run-integration-tests-macos:
     if: contains(inputs.runner, 'macos')

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -80,8 +80,10 @@ jobs:
       # missing: lsof, parallel, bc
       - name: Install dependencies
         run: |
-          choco install netcat httpie kubectl
+          choco install netcat httpie
         shell: bash
+
+      - uses: azure/setup-kubectl@v3
 
       - name: Install Bats
         uses: mig4/setup-bats@v1
@@ -160,6 +162,7 @@ jobs:
           # brew update
           brew install netcat lsof parallel httpie bc coreutils
         shell: bash
+      - uses: azure/setup-kubectl@v3
       - name: Install Bats
         uses: mig4/setup-bats@v1
         with:

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -87,7 +87,7 @@
             URL="${URL}/v${{ inputs.calyptia-cli-version }}"
             URL="${URL}/cli_${{ inputs.calyptia-cli-version }}_windows_amd64.tar.gz"
             echo "Calyptia CLI URL: ${URL}"
-            curl "${URL}" --output /tmp/calyptia-cli.tar.gz
+            curl -L "${URL}" --output /tmp/calyptia-cli.tar.gz
             mkdir -p /tmp/calyptia-cli/
             tar zxvf /tmp/calyptia-cli.tar.gz -C /tmp/calyptia-cli/
             echo "path=/tmp/calyptia-cli" >> "${GITHUB_OUTPUT}"
@@ -166,7 +166,7 @@
             URL="${URL}/v${{ inputs.calyptia-cli-version }}"
             URL="${URL}/cli_${{ inputs.calyptia-cli-version }}_darwin"
             URL="${URL}_${{ steps.pkgarch.outputs.arch }}.tar.gz"
-            curl "${URL}" --output /tmp/calyptia-cli.tar.gz
+            curl -L "${URL}" --output /tmp/calyptia-cli.tar.gz
             echo "Calyptia CLI URL: ${URL}"
             mkdir -p /tmp/calyptia-cli/
             tar zxvf /tmp/calyptia-cli.tar.gz -C /tmp/calyptia-cli/

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -1,0 +1,167 @@
+---
+  name: Reusable workflow to run integration tests
+  on:
+    workflow_call:
+      inputs:
+        cli-version:
+          type: string
+          required: false
+          default: latest
+          description: release version of the calyptia cli to use.
+        calyptia-lts-version:
+          type: string
+          required: true
+          description: release version of calyptia fluent-bit lts to use.
+        ref:
+          description: The commit, tag or branch of this repository to checkout
+          type: string
+          required: false
+          default: refs/heads/main
+        calyptia-tests:
+          description: Path to tests to be executed
+          type: string
+          required: false
+        runner:
+          description: The runner to use for tests.
+          type: string
+          required: false
+          default: actuated-4cpu-16gb
+        calyptia-lts-repo:
+          description: URL with calyptia fluent-bit lts packages
+          type: string
+          required: false
+          default: https://calyptia-lts-staging-standard.s3.amazonaws.com
+      secrets:
+        github-token:
+          description: The Github token for checking out the code.
+          required: false # TODO: switch over once done
+  env:
+    CALYPTIA_CLI_VERSION: ${{ inputs.cli-version }}
+
+  jobs:
+    verify-inputs:
+      name: Verify inputs
+      runs-on: ubuntu-latest
+      permissions: {}
+      steps:
+        - name: Success
+          run: echo "Checks complete"
+          shell: bash
+
+    setup-bats:
+      runs-on: ${{ inputs.runner }}
+      steps:
+        - name: Setup BATS
+          uses: mig4/setup-bats@v1
+          with:
+            bats-version: 1.10.0
+
+    run-integration-tests-windows:
+      if: contains(inputs.runner, 'windows')
+      runs-on: ${{ inputs.runner }}
+      needs:
+        - setup-bats
+        - verify-inputs
+      steps:
+        # missing: lsof, parallel, bc
+        - name: Install dependencies
+          run: |
+            brew update
+            choco install netcat httpie jq python3 coreutils
+          shell: bash
+        - name: Download and Install Calyptia Fluent-Bit LTS Package
+          id: pkginstall
+          shell: bash
+          run: |
+            URL="${{ inputs.calyptia-lts-repo }}/windows"
+            URL="${URL}/${{ inputs.calyptia-lts-version }}"
+            URL="${URL}/calyptia-fluent-bit-${{ inputs.calyptia-lts-version }}-win64.zip"
+            curl "${URL}" --output calyptia-fluent-bit-win64.zip
+            unzip calyptia-fluent-bit-win64.zip -d /tmp
+            mv /tmp/calyptia-fluent-bit-* /tmp/calyptia-fluent-bit
+            echo "bin=/tmp/calyptia-fluent-bit/bin/calyptia-fluent-bit" >> "${GITHUB_OUTPUT}"
+        - name: Checkout the Code
+          uses: actions/checkout@v4
+          with:
+            repository: calyptia/cloud-e2e
+            ref: ${{ inputs.ref }}
+            token: ${{ secrets.github-token }}
+        - name: Run bats tests
+          run: |
+            export CALYPTIA_CLOUD_URL=http://127.0.0.1:8080
+            export CALYPTIA_CLOUD_TOKEN=eyJQcm9qZWN0SUQiOiJmb29iYXIifQ.faketoken
+            (cd mock-fleet-api;
+              go run main.go > /dev/null &
+              echo $! > ../MOCK.PID
+            )
+            ./run-bats.sh ${{ inputs.calyptia-tests }}
+            kill -9 "$(cat MOCK.PID)"
+          shell: bash
+          timeout-minutes: 30
+          env:
+            TEST_UID: ${{ github.repository }}-${{ github.run_id }}-${{ strategy.job-index }}
+            FLUENTBIT_BIN: ${{ steps.pkginstall.outputs.bin }}
+
+    run-integration-tests-macos:
+      if: contains(inputs.runner, 'macos')
+      runs-on: ${{ inputs.runner }}
+      needs:
+        - setup-bats
+        - verify-inputs
+      steps:
+        - name: Install dependencies
+          run: |
+            # missing: time (reserved shell keyword)
+            brew update
+            brew install netcat lsof parallel httpie jq bc python3 coreutils
+          shell: bash
+        - name: Set Architecture Package according to runner
+          id: pkgarch
+          run: |
+            echo -n "Runner architecture: "
+            uname -m
+            if [ "$(uname -m)" == "arm64" ]; then
+              echo "arch=apple" >> "${GITHUB_OUTPUT}"
+            else
+              echo "arch=intel" >> "${GITHUB_OUTPUT}"
+            fi
+        - name: Download and Install Calyptia Fluent-Bit LTS Package
+          id: pkginstall
+          shell: bash
+          run: |
+            URL="${{ inputs.calyptia-lts-repo }}/macos"
+            URL="${URL}/${{ inputs.calyptia-lts-version }}"
+            URL="${URL}/calyptia-fluent-bit-${{ inputs.calyptia-lts-version }}-${{ steps.pkgarch.outputs.arch }}.pkg"
+            wget "${URL}" -O calyptia-fluent-bit.pkg
+            installer -pkg calyptia-fluent-bit.pkg -target CurrentUserHomeDirectory
+            # pkgutil --lsbom io.fluentbit.calyptia-fluent-bit.binary --volume $HOME
+            echo "bin=${HOME}/./usr/local/bin/calyptia-fluent-bit" >> "${GITHUB_OUTPUT}"
+        - name: Checkout the Code
+          uses: actions/checkout@v4
+          with:
+            repository: calyptia/cloud-e2e
+            ref: ${{ inputs.ref }}
+            token: ${{ secrets.github-token }}
+        - name: Checkout the Code for the Mock Server
+          uses: actions/checkout@v4
+          with:
+            repository: calyptia/fleet-mock-api
+            # must also be updated when the initial version is accepted.
+            ref: initial-version
+            path: mock-fleet-api
+            token: ${{ secrets.github-token }}
+        - name: Run bats tests
+          run: |
+            export CALYPTIA_CLOUD_URL=http://127.0.0.1:8080
+            export CALYPTIA_CLOUD_TOKEN=eyJQcm9qZWN0SUQiOiJmb29iYXIifQ.faketoken
+            (cd mock-fleet-api;
+              go run main.go > /dev/null &
+              echo $! > ../MOCK.PID
+            )
+            ./run-bats.sh ${{ inputs.calyptia-tests }}
+            kill -9 "$(cat MOCK.PID)"
+          shell: bash
+          timeout-minutes: 30
+          env:
+            TEST_UID: ${{ github.repository }}-${{ github.run_id }}-${{ strategy.job-index }}
+            FLUENTBIT_BIN: ${{ steps.pkginstall.outputs.bin }}

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -167,7 +167,7 @@
             )
             ./run-bats.sh ${{ inputs.calyptia-tests }}
             kill -9 "$(cat MOCK.PID)"
-          shell: bash
+          # shell: bash
           timeout-minutes: 30
           env:
             TEST_UID: ${{ github.repository }}-${{ github.run_id }}-${{ strategy.job-index }}

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -102,7 +102,7 @@ jobs:
         shell: bash
         # transform download-path into msys2 equivalent
         run: |
-            DP="${{ steps.download.outputs.download-path }}"
+            DP="/tmp/fluent-bit"
             DP=$(echo $DP | sed 's/\([A-Za-z]\)\:/\l\1/' | sed 's/\\/\//g')
             DP="/${DP}"
             mv "${DP}/"*.zip /tmp/calyptia-fluent-bit.zip

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -112,7 +112,7 @@
           run: |
             # missing: time (reserved shell keyword)
             brew update
-            brew install netcat lsof parallel httpie jq bc python3 coreutils
+            brew install netcat lsof parallel httpie jq bc coreutils
           shell: bash
         - name: Set Architecture Package according to runner
           id: pkgarch

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -1,210 +1,185 @@
 ---
-  name: Reusable workflow to run integration tests
-  on:
-    workflow_call:
-      inputs:
-        calyptia-cli-version:
-          type: string
-          required: false
-          default: 1.11.0
-          description: release version of the calyptia cli to use.
-        calyptia-lts-version:
-          type: string
-          required: true
-          description: release version of calyptia fluent-bit lts to use.
-        ref:
-          description: The commit, tag or branch of this repository to checkout
-          type: string
-          required: false
-          default: refs/heads/main
-        calyptia-tests:
-          description: Path to tests to be executed
-          type: string
-          required: false
-        runner:
-          description: The runner to use for tests.
-          type: string
-          required: false
-          default: actuated-4cpu-16gb
-        calyptia-lts-repo:
-          description: URL with calyptia fluent-bit lts packages
-          type: string
-          required: false
-          default: https://calyptia-lts-staging-standard.s3.amazonaws.com
-      secrets:
-        github-token:
-          description: The Github token for checking out the code.
-          required: false # TODO: switch over once done
-  env:
-    CALYPTIA_CLI_VERSION: ${{ inputs.calyptia-cli-version }}
+name: Reusable workflow to run integration tests
+on:
+  workflow_call:
+    inputs:
+      calyptia-cli-version:
+        type: string
+        required: false
+        default: 1.11.0
+        description: release version of the calyptia cli to use.
+      calyptia-lts-version:
+        type: string
+        required: true
+        description: release version of calyptia fluent-bit lts to use.
+      ref:
+        description: The commit, tag or branch of this repository to checkout
+        type: string
+        required: false
+        default: refs/heads/main
+      calyptia-tests:
+        description: Path to tests to be executed
+        type: string
+        required: false
+      runner:
+        description: The runner to use for tests.
+        type: string
+        required: false
+        default: actuated-4cpu-16gb
+      calyptia-lts-repo:
+        description: URL with calyptia fluent-bit lts packages
+        type: string
+        required: false
+        default: https://calyptia-lts-staging-standard.s3.amazonaws.com
+    secrets:
+      CALYPTIA_CLOUD_URL:
+        description: The URL to the cloud instance used for testing.
+        required: true
+      CALYPTIA_CLOUD_TOKEN:
+        description: |
+          The token used to authenticate to the cloud instance used for
+          testing.
+        required: true
+      github-token:
+        description: The Github token for checking out the code.
+        # TODO: switch over once done
+        required: false
+env:
+  CALYPTIA_CLI_VERSION: ${{ inputs.calyptia-cli-version }}
 
-  jobs:
-    verify-inputs:
-      name: Verify inputs
-      runs-on: ubuntu-latest
-      permissions: {}
-      steps:
-        - name: Success
-          run: echo "Checks complete"
-          shell: bash
+jobs:
+  verify-inputs:
+    name: Verify inputs
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Success
+        run: echo "Checks complete"
+        shell: bash
 
-    run-integration-tests-windows:
-      if: contains(inputs.runner, 'windows')
-      runs-on: ${{ inputs.runner }}
-      needs:
-        - verify-inputs
-      steps:
-        # missing: lsof, parallel, bc
-        - name: Install dependencies
-          run: |
-            choco install netcat httpie
-          shell: bash
-        - name: Install Bats
-          uses: mig4/setup-bats@v1
-          with:
-            bats-version: 1.10.0
-        - name: Download and Install Calyptia Fluent-Bit LTS Package
-          id: pkginstall
-          shell: bash
-          run: |
-            URL="${{ inputs.calyptia-lts-repo }}/windows"
-            URL="${URL}/${{ inputs.calyptia-lts-version }}"
-            URL="${URL}/calyptia-fluent-bit-${{ inputs.calyptia-lts-version }}-win64.zip"
-            curl "${URL}" --output calyptia-fluent-bit-win64.zip
-            unzip calyptia-fluent-bit-win64.zip -d /tmp
-            mv /tmp/calyptia-fluent-bit-* /tmp/calyptia-fluent-bit
-            echo "bin=/tmp/calyptia-fluent-bit/bin/calyptia-fluent-bit" >> "${GITHUB_OUTPUT}"
-        - name: Install Calyptia CLI
-          id: calyptia-cli
-          shell: bash
-          run: |
-            URL="https://github.com/calyptia/cli/releases/download"
-            URL="${URL}/v${{ inputs.calyptia-cli-version }}"
-            URL="${URL}/cli_${{ inputs.calyptia-cli-version }}_windows_amd64.tar.gz"
-            echo "Calyptia CLI URL: ${URL}"
-            curl -L "${URL}" --output /tmp/calyptia-cli.tar.gz
-            mkdir -p /tmp/calyptia-cli/
-            tar zxvf /tmp/calyptia-cli.tar.gz -C /tmp/calyptia-cli/
-            echo "path=/tmp/calyptia-cli" >> "${GITHUB_OUTPUT}"
-        - name: Checkout the Code
-          uses: actions/checkout@v4
-          with:
-            repository: calyptia/cloud-e2e
-            ref: ${{ inputs.ref }}
-            token: ${{ secrets.github-token }}
-        - name: Checkout the Code for the Mock Server
-          uses: actions/checkout@v4
-          with:
-            repository: calyptia/fleet-mock-api
-            # must also be updated when the initial version is accepted.
-            ref: initial-version
-            path: fleet-mock-api
-            token: ${{ secrets.github-token }}
-        - name: Run bats tests
-          run: |
-            export CALYPTIA_CLOUD_URL=http://127.0.0.1:8080
-            export CALYPTIA_CLOUD_TOKEN=eyJQcm9qZWN0SUQiOiJmb29iYXIifQ.faketoken
-            (cd fleet-mock-api;
-              # step RUNNER_TRACKING_ID="" in an attempt to avoid process cleanup
-              go build ./
-              env RUNNER_TRACKING_ID="" ./fleet-mock-api > mock.log &
-              echo $! > ../MOCK.PID
-            )
-            export PATH="${PATH}":${{ steps.calyptia-cli.outputs.path }}
-            sleep 3
-            cat fleet-mock-api/mock.log
-            ./run-bats.sh ${{ inputs.calyptia-tests }}
-            kill -9 "$(cat MOCK.PID)"
-          shell: bash
-          timeout-minutes: 30
-          env:
-            TEST_UID: ${{ github.repository }}-${{ github.run_id }}-${{ strategy.job-index }}
-            FLUENTBIT_BIN: ${{ steps.pkginstall.outputs.bin }}
+  run-integration-tests-windows:
+    if: contains(inputs.runner, 'windows')
+    runs-on: ${{ inputs.runner }}
+    needs:
+      - verify-inputs
+    steps:
+      # missing: lsof, parallel, bc
+      - name: Install dependencies
+        run: |
+          choco install netcat httpie
+        shell: bash
+      - name: Install Bats
+        uses: mig4/setup-bats@v1
+        with:
+          bats-version: 1.10.0
+      - name: Download and Install Calyptia Fluent-Bit LTS Package
+        id: pkginstall
+        shell: bash
+        run: |
+          URL="${{ inputs.calyptia-lts-repo }}/windows"
+          URL="${URL}/${{ inputs.calyptia-lts-version }}"
+          URL="${URL}/calyptia-fluent-bit-${{ inputs.calyptia-lts-version }}-win64.zip"
+          curl "${URL}" --output calyptia-fluent-bit-win64.zip
+          unzip calyptia-fluent-bit-win64.zip -d /tmp
+          mv /tmp/calyptia-fluent-bit-* /tmp/calyptia-fluent-bit
+          echo "bin=/tmp/calyptia-fluent-bit/bin/calyptia-fluent-bit" >> "${GITHUB_OUTPUT}"
+      - name: Install Calyptia CLI
+        id: calyptia-cli
+        shell: bash
+        run: |
+          URL="https://github.com/calyptia/cli/releases/download"
+          URL="${URL}/v${{ inputs.calyptia-cli-version }}"
+          URL="${URL}/cli_${{ inputs.calyptia-cli-version }}_windows_amd64.tar.gz"
+          echo "Calyptia CLI URL: ${URL}"
+          curl -L "${URL}" --output /tmp/calyptia-cli.tar.gz
+          mkdir -p /tmp/calyptia-cli/
+          tar zxvf /tmp/calyptia-cli.tar.gz -C /tmp/calyptia-cli/
+          echo "path=/tmp/calyptia-cli" >> "${GITHUB_OUTPUT}"
+      - name: Checkout the Code
+        uses: actions/checkout@v4
+        with:
+          repository: calyptia/cloud-e2e
+          ref: ${{ inputs.ref }}
+          token: ${{ secrets.github-token }}
+      - name: Run bats tests
+        run: |
+          export PATH="${PATH}":${{ steps.calyptia-cli.outputs.path }}
+          ./run-bats.sh ${{ inputs.calyptia-tests }}
+        shell: bash
+        timeout-minutes: 30
+        env:
+          TEST_UID: ${{ github.repository }}-${{ github.run_id }}-${{ strategy.job-index }}
+          FLUENTBIT_BIN: ${{ steps.pkginstall.outputs.bin }}
+          CALYPTIA_CLOUD_URL: ${{ secrets.CALYPTIA_CLOUD_URL }}
+          CALYPTIA_CLOUD_TOKEN: ${{ secrets.CALYPTIA_CLOUD_TOKEN }}
 
-    run-integration-tests-macos:
-      if: contains(inputs.runner, 'macos')
-      runs-on: ${{ inputs.runner }}
-      needs:
-        - verify-inputs
-      steps:
-        - name: Install dependencies
-          run: |
-            # missing: time (reserved shell keyword)
-            # brew update
-            brew install netcat lsof parallel httpie bc coreutils
-          shell: bash
-        - name: Install Bats
-          uses: mig4/setup-bats@v1
-          with:
-            bats-version: 1.10.0
-        - name: Set Architecture Package according to runner
-          id: pkgarch
-          run: |
-            echo -n "Runner architecture: "
-            uname -m
-            if [ "$(uname -m)" == "arm64" ]; then
-              echo "brand=apple" >> "${GITHUB_OUTPUT}"
-              echo "arch=arm64" >> "${GITHUB_OUTPUT}"
-            else
-              echo "brand=intel" >> "${GITHUB_OUTPUT}"
-              echo "arch=amd64" >> "${GITHUB_OUTPUT}"
-            fi
-        - name: Download and Install Calyptia Fluent-Bit LTS Package
-          id: pkginstall
-          shell: bash
-          run: |
-            URL="${{ inputs.calyptia-lts-repo }}/macos"
-            URL="${URL}/${{ inputs.calyptia-lts-version }}"
-            URL="${URL}/calyptia-fluent-bit-${{ inputs.calyptia-lts-version }}-${{ steps.pkgarch.outputs.brand }}.pkg"
-            wget "${URL}" -O calyptia-fluent-bit.pkg
-            installer -pkg calyptia-fluent-bit.pkg -target CurrentUserHomeDirectory
-            # pkgutil --lsbom io.fluentbit.calyptia-fluent-bit.binary --volume $HOME
-            echo "bin=${HOME}/./usr/local/bin/calyptia-fluent-bit" >> "${GITHUB_OUTPUT}"
-        - name: Install Calyptia CLI
-          id: calyptia-cli
-          shell: bash
-          run: |
-            URL="https://github.com/calyptia/cli/releases/download"
-            URL="${URL}/v${{ inputs.calyptia-cli-version }}"
-            URL="${URL}/cli_${{ inputs.calyptia-cli-version }}_darwin"
-            URL="${URL}_${{ steps.pkgarch.outputs.arch }}.tar.gz"
-            curl -L "${URL}" --output /tmp/calyptia-cli.tar.gz
-            echo "Calyptia CLI URL: ${URL}"
-            mkdir -p /tmp/calyptia-cli/
-            tar zxvf /tmp/calyptia-cli.tar.gz -C /tmp/calyptia-cli/
-            echo "path=/tmp/calyptia-cli" >> "${GITHUB_OUTPUT}"
-        - name: Checkout the Code
-          uses: actions/checkout@v4
-          with:
-            repository: calyptia/cloud-e2e
-            ref: ${{ inputs.ref }}
-            token: ${{ secrets.github-token }}
-        - name: Checkout the Code for the Mock Server
-          uses: actions/checkout@v4
-          with:
-            repository: calyptia/fleet-mock-api
-            # must also be updated when the initial version is accepted.
-            ref: initial-version
-            path: fleet-mock-api
-            token: ${{ secrets.github-token }}
-        - name: Run bats tests
-          shell: bash
-          run: |
-            export CALYPTIA_CLOUD_URL=http://127.0.0.1:8080
-            export CALYPTIA_CLOUD_TOKEN=eyJQcm9qZWN0SUQiOiJmb29iYXIifQ.faketoken
-            (cd fleet-mock-api;
-              # step RUNNER_TRACKING_ID="" in an attempt to avoid process cleanup
-              go build ./
-              env RUNNER_TRACKING_ID="" ./fleet-mock-api > mock.log &
-              echo $! > ../MOCK.PID
-            )
-            export PATH="${PATH}":${{ steps.calyptia-cli.outputs.path }}
-            sleep 3
-            cat fleet-mock-api/mock.log
-            ./run-bats.sh ${{ inputs.calyptia-tests }}
-            kill -9 "$(cat MOCK.PID)"
-          # shell: bash
-          timeout-minutes: 30
-          env:
-            TEST_UID: ${{ github.repository }}-${{ github.run_id }}-${{ strategy.job-index }}
-            FLUENTBIT_BIN: ${{ steps.pkginstall.outputs.bin }}
+  run-integration-tests-macos:
+    if: contains(inputs.runner, 'macos')
+    runs-on: ${{ inputs.runner }}
+    needs:
+      - verify-inputs
+    steps:
+      - name: Install dependencies
+        run: |
+          # missing: time (reserved shell keyword)
+          # brew update
+          brew install netcat lsof parallel httpie bc coreutils
+        shell: bash
+      - name: Install Bats
+        uses: mig4/setup-bats@v1
+        with:
+          bats-version: 1.10.0
+      - name: Set Architecture Package according to runner
+        id: pkgarch
+        run: |
+          echo -n "Runner architecture: "
+          uname -m
+          if [ "$(uname -m)" == "arm64" ]; then
+            echo "brand=apple" >> "${GITHUB_OUTPUT}"
+            echo "arch=arm64" >> "${GITHUB_OUTPUT}"
+          else
+            echo "brand=intel" >> "${GITHUB_OUTPUT}"
+            echo "arch=amd64" >> "${GITHUB_OUTPUT}"
+          fi
+      - name: Download and Install Calyptia Fluent-Bit LTS Package
+        id: pkginstall
+        shell: bash
+        run: |
+          URL="${{ inputs.calyptia-lts-repo }}/macos"
+          URL="${URL}/${{ inputs.calyptia-lts-version }}"
+          URL="${URL}/calyptia-fluent-bit-${{ inputs.calyptia-lts-version }}-${{ steps.pkgarch.outputs.brand }}.pkg"
+          wget "${URL}" -O calyptia-fluent-bit.pkg
+          installer -pkg calyptia-fluent-bit.pkg -target CurrentUserHomeDirectory
+          # pkgutil --lsbom io.fluentbit.calyptia-fluent-bit.binary --volume $HOME
+          echo "bin=${HOME}/./usr/local/bin/calyptia-fluent-bit" >> "${GITHUB_OUTPUT}"
+      - name: Install Calyptia CLI
+        id: calyptia-cli
+        shell: bash
+        run: |
+          URL="https://github.com/calyptia/cli/releases/download"
+          URL="${URL}/v${{ inputs.calyptia-cli-version }}"
+          URL="${URL}/cli_${{ inputs.calyptia-cli-version }}_darwin"
+          URL="${URL}_${{ steps.pkgarch.outputs.arch }}.tar.gz"
+          curl -L "${URL}" --output /tmp/calyptia-cli.tar.gz
+          echo "Calyptia CLI URL: ${URL}"
+          mkdir -p /tmp/calyptia-cli/
+          tar zxvf /tmp/calyptia-cli.tar.gz -C /tmp/calyptia-cli/
+          echo "path=/tmp/calyptia-cli" >> "${GITHUB_OUTPUT}"
+      - name: Checkout the Code
+        uses: actions/checkout@v4
+        with:
+          repository: calyptia/cloud-e2e
+          ref: ${{ inputs.ref }}
+          token: ${{ secrets.github-token }}
+      - name: Run bats tests
+        shell: bash
+        run: |
+          export PATH="${PATH}":${{ steps.calyptia-cli.outputs.path }}
+          ./run-bats.sh ${{ inputs.calyptia-tests }}
+        # shell: bash
+        timeout-minutes: 30
+        env:
+          CALYPTIA_CLOUD_URL: ${{ secrets.CALYPTIA_CLOUD_URL }}
+          CALYPTIA_CLOUD_TOKEN: ${{ secrets.CALYPTIA_CLOUD_TOKEN }}
+          TEST_UID: ${{ github.repository }}-${{ github.run_id }}-${{ strategy.job-index }}
+          FLUENTBIT_BIN: ${{ steps.pkginstall.outputs.bin }}

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -91,6 +91,7 @@ jobs:
             DP="${{ steps.download.outputs.download-path }}"
             DP=$(echo $DP | sed 's/\([A-Za-z]\)\:/\l\1/' | sed 's/\\/\//g')
             DP="/${DP}"
+            ls -alF "${DP}"
             # unzip the one zip in download path which should be the calyptia
             # package zip.
             mv "${DP}/*.zip" /tmp/calyptia-fluent-bit.zip

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -101,12 +101,12 @@ jobs:
           URL="${URL}/${{ inputs.calyptia-lts-version }}"
           URL="${URL}/calyptia-fluent-bit"
           URL="${URL}-${{ inputs.calyptia-lts-version }}-win64.zip"
-          curl "${URL}" --output calyptia-fluent-bit-win64.zip
+          curl "${URL}" --output calyptia-fluent-bit.zip
       - name: Unzip Calyptia Package
         shell: bash
         id: pkginstall
         run: |
-          unzip calyptia-fluent-bit-win64.zip -d /tmp
+          unzip calyptia-fluent-bit.zip -d /tmp
           mv /tmp/calyptia-fluent-bit-* /tmp/calyptia-fluent-bit
           echo "bin=/tmp/calyptia-fluent-bit/bin/calyptia-fluent-bit" \
             >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,9 +88,9 @@ jobs:
       runner: "${{ matrix.runner }}"
       # update to main when changes have been merged
       ref: pwhelan-fleet-e2e
+      calyptia-cloud-url: "https://cloud-api-dev.calyptia.com"
     secrets:
       github-token: ${{ secrets.CI_PAT }}
-      calyptia-cloud-url: ${{ secrets.CALYPTIA_CLOUD_URL }}
       calyptia-cloud-token: ${{ secrets.CALYPTIA_CLOUD_TOKEN }}
 
   ci-generate-reports:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,26 +72,27 @@ jobs:
       google-access-key: ${{ secrets.GCP_SA_KEY }}
       github-token: ${{ secrets.CI_PAT }}
 
-  ci-fleet-tests:
-    uses: ./.github/workflows/call-fleet-integration-tests.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        testset:
-          - fleet/cli
-        runner:
-          - macos-latest
-          - windows-latest
-    with:
-      calyptia-tests: "${{ matrix.testset }}/"
-      calyptia-lts-version: 23.10.2
-      runner: "${{ matrix.runner }}"
-      # update to main when changes have been merged
-      ref: pwhelan-fleet-e2e
-      calyptia-cloud-url: "https://cloud-api-dev.calyptia.com"
-    secrets:
-      github-token: ${{ secrets.CI_PAT }}
-      calyptia-cloud-token: ${{ secrets.CALYPTIA_CLOUD_TOKEN }}
+  # TODO: add fleet tests once ready
+  # ci-fleet-tests:
+  #   uses: ./.github/workflows/call-fleet-integration-tests.yaml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       testset:
+  #         - fleet/cli
+  #       runner:
+  #         - macos-latest
+  #         - windows-latest
+  #   with:
+  #     calyptia-tests: "${{ matrix.testset }}/"
+  #     calyptia-lts-version: 23.10.2
+  #     runner: "${{ matrix.runner }}"
+  #     # # update to main when changes have been merged
+  #     # ref: pwhelan-fleet-e2e
+  #     calyptia-cloud-url: "https://cloud-api-dev.calyptia.com"
+  #   secrets:
+  #     github-token: ${{ secrets.CI_PAT }}
+  #     calyptia-cloud-token: ${{ secrets.CALYPTIA_CLOUD_TOKEN }}
 
   ci-generate-reports:
     name: Generate SBOM and CVE reports for release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,8 @@ jobs:
       ref: pwhelan-fleet-e2e
     secrets:
       github-token: ${{ secrets.CI_PAT }}
+      CALYPTIA_CLOUD_URL: ${{ secrets.CALYPTIA_CLOUD_URL }}
+      CALYPTIA_CLOUD_TOKEN: ${{ secrets.CALYPTIA_CLOUD_TOKEN }}
 
   ci-generate-reports:
     name: Generate SBOM and CVE reports for release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,8 @@ jobs:
       ref: pwhelan-fleet-e2e
     secrets:
       github-token: ${{ secrets.CI_PAT }}
-      CALYPTIA_CLOUD_URL: ${{ secrets.CALYPTIA_CLOUD_URL }}
-      CALYPTIA_CLOUD_TOKEN: ${{ secrets.CALYPTIA_CLOUD_TOKEN }}
+      calyptia-cloud-url: ${{ secrets.CALYPTIA_CLOUD_URL }}
+      calyptia-cloud-token: ${{ secrets.CALYPTIA_CLOUD_TOKEN }}
 
   ci-generate-reports:
     name: Generate SBOM and CVE reports for release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ concurrency:
 jobs:
   ci-get-metadata:
     uses: ./.github/workflows/get-versions.yaml
-    secrets:
-      github-token: ${{ secrets.CI_PAT }}
 
   ci-e2e-tests:
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ concurrency:
 jobs:
   ci-get-metadata:
     uses: ./.github/workflows/get-versions.yaml
+    secrets:
+      github-token: ${{ secrets.CI_PAT }}
 
   ci-e2e-tests:
     needs:
@@ -70,6 +72,25 @@ jobs:
       registry-password: ${{ secrets.CI_PAT }}
       # Replace with playground key after: https://app.asana.com/0/1205042382663691/1205231066738712/f
       google-access-key: ${{ secrets.GCP_SA_KEY }}
+      github-token: ${{ secrets.CI_PAT }}
+
+  ci-fleet-tests:
+    uses: ./.github/workflows/call-fleet-integration-tests.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        testset:
+          - fleet/cli
+        runner:
+          - macos-latest
+          - windows-latest
+    with:
+      calyptia-tests: "${{ matrix.testset }}/"
+      calyptia-lts-version: 23.10.2
+      runner: "${{ matrix.runner }}"
+      # update to main when changes have been merged
+      ref: pwhelan-fleet-e2e
+    secrets:
       github-token: ${{ secrets.CI_PAT }}
 
   ci-generate-reports:


### PR DESCRIPTION
# Summary

This PR adds a new job to ci.yml as well as a new workflow which:

- Downloads a version of calyptia lts from staging (the version is passed as an input)
- Installs that version
- Executes the fleet/cli bats tests with it.

At the moment it is configured to run with windows-latest and macos-latest. To run it on Apple M1 macs we will need to configure the macos-xlarge-latest runner as well.

This hopefully should be the basis for future LTS tests for windows and macos. Comments welcome.

# Notes

There are still a few hardcoded branches which need to be merged before using main:

- fleet-mock-api
- cloud-e2e

I will also attempt to add `get-versions` to the fleet workflow.