### PR TITLE
workflows: fix release workflow when branch exists in core-docs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -169,7 +169,7 @@ jobs:
 
         - name: Create or checkout branch
           run: |
-            if git show-branch "$BRANCH" &> /dev/null; then
+            if git ls-remote --exit-code --heads origin refs/heads/"$BRANCH" &> /dev/null; then
               git checkout "$BRANCH"
             else
               git checkout -b "$BRANCH"


### PR DESCRIPTION
Resolves issue with incorrect `git` check command for existing branch: https://github.com/calyptia/core-product-release/actions/runs/7019781317/job/19098050664