### PR TITLE
workflows: support custom CLI versions

### DIFF
--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -6,7 +6,7 @@ on:
       calyptia-cli-version:
         type: string
         required: false
-        default: 1.11.0
+        default: latest
         description: release version of the calyptia cli to use.
       calyptia-package-artefact:
         type: string
@@ -119,19 +119,16 @@ jobs:
           mv /tmp/calyptia-fluent-bit-* /tmp/calyptia-fluent-bit
           echo "bin=/tmp/calyptia-fluent-bit/bin/calyptia-fluent-bit" >> "${GITHUB_OUTPUT}"
 
-      - name: Install Calyptia CLI
-        id: calyptia-cli
-        shell: bash
-        run: |
-          URL="https://github.com/calyptia/cli/releases/download"
-          URL="${URL}/v${{ inputs.calyptia-cli-version }}"
-          URL="${URL}/cli_${{ inputs.calyptia-cli-version }}"
-          URL="${URL}_windows_amd64.tar.gz"
-          echo "Calyptia CLI URL: ${URL}"
-          curl -L "${URL}" --output /tmp/calyptia-cli.tar.gz
-          mkdir -p /tmp/calyptia-cli/
-          tar zxvf /tmp/calyptia-cli.tar.gz -C /tmp/calyptia-cli/
-          echo "path=/tmp/calyptia-cli" >> "${GITHUB_OUTPUT}"
+      - name: Install CLI
+        uses: engineerd/configurator@v0.0.10
+        with:
+          name: calyptia
+          version: ${{ inputs.calyptia-cli-version }}
+          fromGitHubReleases: true
+          includePrereleases: false
+          repo: calyptia/cli
+          token: ${{ secrets.github-token }}
+          urlTemplate: https://github.com/calyptia/cli/releases/download/{{ version }}/v{{ version }}/cli_{{ version }}_windows_amd64.tar.gz
 
       - name: Checkout the Code
         uses: actions/checkout@v4
@@ -192,19 +189,18 @@ jobs:
           installer -pkg calyptia-fluent-bit.pkg -target CurrentUserHomeDirectory
           # pkgutil --lsbom io.fluentbit.calyptia-fluent-bit.binary --volume $HOME
           echo "bin=${HOME}/./usr/local/bin/calyptia-fluent-bit" >> "${GITHUB_OUTPUT}"
-      - name: Install Calyptia CLI
-        id: calyptia-cli
-        shell: bash
-        run: |
-          URL="https://github.com/calyptia/cli/releases/download"
-          URL="${URL}/v${{ inputs.calyptia-cli-version }}"
-          URL="${URL}/cli_${{ inputs.calyptia-cli-version }}_darwin"
-          URL="${URL}_${{ steps.pkgarch.outputs.arch }}.tar.gz"
-          curl -L "${URL}" --output /tmp/calyptia-cli.tar.gz
-          echo "Calyptia CLI URL: ${URL}"
-          mkdir -p /tmp/calyptia-cli/
-          tar zxvf /tmp/calyptia-cli.tar.gz -C /tmp/calyptia-cli/
-          echo "path=/tmp/calyptia-cli" >> "${GITHUB_OUTPUT}"
+
+      - name: Install CLI
+        uses: engineerd/configurator@v0.0.10
+        with:
+          name: calyptia
+          version: ${{ inputs.calyptia-cli-version }}
+          fromGitHubReleases: true
+          includePrereleases: false
+          repo: calyptia/cli
+          token: ${{ secrets.github-token }}
+          urlTemplate: https://github.com/calyptia/cli/releases/download/{{ version }}/v{{ version }}/cli_{{ version }}_darwin_${{ steps.pkgarch.outputs.arch }}.tar.gz
+
       - name: Checkout the Code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/call-integration-tests.yaml
+++ b/.github/workflows/call-integration-tests.yaml
@@ -11,8 +11,8 @@
         cli-image:
           type: string
           required: false
-          default: ghcr.io/calyptia/cli:main
-          description: CLI image to use.
+          default: ''
+          description: CLI image to use to extract a custom binary from, only use this for PRs or similar.
         cloud-image:
           type: string
           required: false
@@ -102,7 +102,6 @@
     AWS_EC2_METADATA_DISABLED: true
     FLUENTD_VERSION: ${{ inputs.fluentd-version }}
     CALYPTIA_CLI_VERSION: ${{ inputs.cli-version }}
-    CALYPTIA_CLI_IMAGE: ${{ inputs.cli-image }}
     CALYPTIA_CLOUD_IMAGE: ${{ inputs.cloud-image }}
     CALYPTIA_CORE_IMAGE: ${{ inputs.core-image }}
     CALYPTIA_CORE_OPERATOR_IMAGE: ${{ inputs.core-operator-image }}
@@ -311,6 +310,32 @@
             kind load docker-image $CALYPTIA_CORE_OPERATOR_FROM_CLOUD_IMAGE
           shell: bash
 
+        - name: Install custom CLI version
+          id: custom-cli-version
+          if: inputs.cli-image != ''
+          run: |
+            docker pull "$CALYPTIA_CLI_IMAGE"
+            docker image save "$CALYPTIA_CLI_IMAGE" | tar --extract --wildcards --to-stdout '*/layer.tar' | tar --extract --ignore-zeros --verbose --directory="/tmp" 'calyptia'
+            sudo mv /tmp/calyptia /usr/local/bin/calyptia
+            sudo chmod a+x /usr/local/bin/calyptia
+          shell: bash
+          env:
+            CALYPTIA_CLI_IMAGE: ${{ inputs.cli-image }}
+
+        - name: Install released CLI version
+          if: inputs.cli-image == ''
+          run: |
+            curl -sSfL https://raw.githubusercontent.com/calyptia/cli/main/install.sh | bash
+          shell: bash
+          env:
+            cli_VERSION: ${{ inputs.cli-version }}
+            GITHUB_TOKEN: ${{ secrets.github-token }}
+            DEBUG: true
+
+        - name: Test version of CLI
+          run: calyptia version
+          shell: bash
+
         - name: Set up Cloud SDK
           uses: google-github-actions/setup-gcloud@v1
 
@@ -401,6 +426,32 @@
           with:
             name: ${{ inputs.core-operator-crd-manifest }}
             path: override
+
+        - name: Install custom CLI version
+          id: custom-cli-version
+          if: inputs.cli-image != ''
+          run: |
+            docker pull "$CALYPTIA_CLI_IMAGE"
+            docker image save "$CALYPTIA_CLI_IMAGE" | tar --extract --wildcards --to-stdout '*/layer.tar' | tar --extract --ignore-zeros --verbose --directory="/tmp" 'calyptia'
+            sudo mv /tmp/calyptia /usr/local/bin/calyptia
+            sudo chmod a+x /usr/local/bin/calyptia
+          shell: bash
+          env:
+            CALYPTIA_CLI_IMAGE: ${{ inputs.cli-image }}
+
+        - name: Install released CLI version
+          if: inputs.cli-image == ''
+          run: |
+            curl -sSfL https://raw.githubusercontent.com/calyptia/cli/main/install.sh | bash
+          shell: bash
+          env:
+            cli_VERSION: ${{ inputs.cli-version }}
+            GITHUB_TOKEN: ${{ secrets.github-token }}
+            DEBUG: true
+
+        - name: Test version of CLI
+          run: calyptia version
+          shell: bash
 
         - id: 'auth'
           uses: 'google-github-actions/auth@v2'

--- a/.github/workflows/call-integration-tests.yaml
+++ b/.github/workflows/call-integration-tests.yaml
@@ -158,6 +158,13 @@
             exit 1
           shell: bash
 
+        - name: Check CLI version or image is set
+          if: inputs.cli-image == '' && inputs.cli-version == ''
+          run: |
+            echo "Invalid CLI configuration detected"
+            exit 1
+          shell: bash
+
         - name: Success
           run: echo "Checks complete"
           shell: bash
@@ -195,12 +202,6 @@
         - name: Set up Actuated mirror
           if: contains(inputs.runner, 'actuated')
           uses: self-actuated/hub-mirror@master
-
-        # - name: Prep SSH access just in case
-        #   # https://github.com/mxschmitt/action-tmate#detached-mode
-        #   uses: mxschmitt/action-tmate@v3
-        #   with:
-        #     detached: true
 
         - name: Checkout the Code
           uses: actions/checkout@v4
@@ -324,13 +325,15 @@
 
         - name: Install released CLI version
           if: inputs.cli-image == ''
-          run: |
-            curl -sSfL https://raw.githubusercontent.com/calyptia/cli/main/install.sh | bash
-          shell: bash
-          env:
-            cli_VERSION: ${{ inputs.cli-version }}
-            GITHUB_TOKEN: ${{ secrets.github-token }}
-            DEBUG: true
+          uses: engineerd/configurator@v0.0.10
+          with:
+            name: calyptia
+            version: ${{ inputs.cli-version }}
+            fromGitHubReleases: true
+            includePrereleases: false
+            repo: calyptia/cli
+            token: ${{ secrets.github-token }}
+            urlTemplate: https://github.com/calyptia/cli/releases/download/{{ version }}/v{{ version }}/cli_{{ version }}_linux_amd64.tar.gz
 
         - name: Test version of CLI
           run: calyptia version
@@ -441,13 +444,15 @@
 
         - name: Install released CLI version
           if: inputs.cli-image == ''
-          run: |
-            curl -sSfL https://raw.githubusercontent.com/calyptia/cli/main/install.sh | bash
-          shell: bash
-          env:
-            cli_VERSION: ${{ inputs.cli-version }}
-            GITHUB_TOKEN: ${{ secrets.github-token }}
-            DEBUG: true
+          uses: engineerd/configurator@v0.0.10
+          with:
+            name: calyptia
+            version: ${{ inputs.cli-version }}
+            fromGitHubReleases: true
+            includePrereleases: false
+            repo: calyptia/cli
+            token: ${{ secrets.github-token }}
+            urlTemplate: https://github.com/calyptia/cli/releases/download/{{ version }}/v{{ version }}/cli_{{ version }}_linux_amd64.tar.gz
 
         - name: Test version of CLI
           run: calyptia version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,6 @@ jobs:
     # uses: calyptia/cloud-e2e/.github/workflows/call-integration-tests.yaml@main
     # Instead we have to replicate the same workflow locally
     uses: ./.github/workflows/call-integration-tests.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        testset:
-          - operator-install
-          - operator
     with:
       cli-version: v${{ needs.ci-get-metadata.outputs.cli-version }}
       cloud-image: ghcr.io/calyptia/cloud:${{ needs.ci-get-metadata.outputs.cloud-version }}
@@ -50,12 +44,6 @@ jobs:
     # uses: calyptia/cloud-e2e/.github/workflows/call-integration-tests.yaml@main
     # Instead we have to replicate the same workflow locally
     uses: ./.github/workflows/call-integration-tests.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        testset:
-          - operator-install
-          - operator
     with:
       cli-version: v${{ needs.ci-get-metadata.outputs.cli-version }}
       cloud-image: ghcr.io/calyptia/cloud:${{ needs.ci-get-metadata.outputs.cloud-version }}


### PR DESCRIPTION
Add support for using non-released versions of the CLI via the container images created by PRs.