### PR TITLE
workflows: trigger remote dispach to private repo for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,6 +61,42 @@ jobs:
                 sbom-cves.tar.gz
             generate_release_notes: false
 
+    ci-trigger-notifications:
+      name: Trigger updates on private repos
+      runs-on: ubuntu-latest
+      needs:
+          - ci-get-metadata
+          - ci-release
+      permissions:
+        contents: read
+      strategy:
+        matrix:
+          repo: ['calyptia/infra-gitops-configuration', 'calyptia/chart-cloud-standalone', 'calyptia/core-docs']
+      steps:
+        - uses: actions/checkout@v4
+
+        - name: Get component config
+          id: get-components
+          run: |
+            CONFIG=$(jq -cr . component-config.json)
+            echo "config=$CONFIG"
+            echo "config=$CONFIG" >> $GITHUB_OUTPUT
+          shell: bash
+
+        - name: Repository Dispatch
+          uses: peter-evans/repository-dispatch@v2
+          with:
+            token: ${{ secrets.CI_PAT }}
+            repository: ${{ matrix.repo }}
+            event-type: core-product-release
+            # The github.ref_name will give them the actual release tag to use but we also inject the component versions directly
+            client-payload: |-
+              {
+                "github": ${{ toJson(github) }},
+                "components": ${{ steps.get-components.outputs.config }}
+              }
+
+    # TODO: move to private repo using repository_dispatch
     ci-update-self-hosted:
         name: Update self-hosted chart to use matching versions
         # We cannot invoke a reusable workflow on the private repo so have to assume some coupling here.
@@ -139,6 +175,7 @@ jobs:
           env:
             GH_TOKEN: ${{ secrets.CI_PAT }}
 
+    # TODO: move to private repo using repository_dispatch
     ci-update-docs:
         name: Update Core Docs with new version
         runs-on: ubuntu-latest


### PR DESCRIPTION
Move to a repository_dispatch decoupled method for workflow updates on release.