### PR TITLE
workflows: add fleet tests

### DIFF
--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -108,9 +108,9 @@ jobs:
         if: ${{ inputs.calyptia-package-artefact }}
         # transform download-path into msys2 equivalent
         run: |
-            DP="/tmp/fluent-bit"
-            DP=$(echo $DP | sed 's/\([A-Za-z]\)\:/\l\1/' | sed 's/\\/\//g')
-            mv "/${DP}/"*.zip /tmp/calyptia-fluent-bit.zip
+          DP="/tmp/fluent-bit"
+          DP=$(echo $DP | sed 's/\([A-Za-z]\)\:/\l\1/' | sed 's/\\/\//g')
+          mv "/${DP}/"*.zip /tmp/calyptia-fluent-bit.zip
         shell: bash
 
       - name: Unzip Calyptia Package
@@ -171,42 +171,65 @@ jobs:
     needs:
       - verify-inputs
     steps:
+      - name: Checkout the Code
+        uses: actions/checkout@v4
+        with:
+          repository: calyptia/cloud-e2e
+          ref: ${{ inputs.ref }}
+          token: ${{ secrets.github-token }}
+
       - name: Install dependencies
         run: |
           # missing: time (reserved shell keyword)
           # brew update
           brew install netcat lsof parallel httpie bc coreutils
         shell: bash
+
       - uses: azure/setup-kubectl@v3
+
       - name: Install Bats
         uses: mig4/setup-bats@v1
         with:
           bats-version: 1.10.0
+
       - name: Set Architecture Package according to runner
         id: pkgarch
         run: |
           echo -n "Runner architecture: "
           uname -m
           if [ "$(uname -m)" == "arm64" ]; then
+            echo "Detected Apple Silicon"
             echo "brand=apple" >> "${GITHUB_OUTPUT}"
             echo "arch=arm64" >> "${GITHUB_OUTPUT}"
           else
+            echo "Detected Intel Silicon"
             echo "brand=intel" >> "${GITHUB_OUTPUT}"
             echo "arch=amd64" >> "${GITHUB_OUTPUT}"
           fi
-      # TODO: add package usage
-      - name: Download and Install Calyptia Fluent-Bit LTS Package
-        id: pkginstall
-        if: inputs.calyptia-lts-version != ''
         shell: bash
+
+      - name: Download Fluent-Bit Binary from Artefact
+        if: ${{ inputs.calyptia-package-artefact }}
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.calyptia-package-artefact }}
+          path: /tmp/fluent-bit
+
+      - name: Download and Install Calyptia FluentBit LTS Package
+        if: inputs.calyptia-lts-version != ''
         run: |
-          URL="${{ inputs.calyptia-lts-repo }}/macos"
-          URL="${URL}/${{ inputs.calyptia-lts-version }}"
-          URL="${URL}/calyptia-fluent-bit-${{ inputs.calyptia-lts-version }}-${{ steps.pkgarch.outputs.brand }}.pkg"
-          wget "${URL}" -O calyptia-fluent-bit.pkg
-          installer -pkg calyptia-fluent-bit.pkg -target CurrentUserHomeDirectory
+          wget "${URL}" -O /tmp/fluent-bit/calyptia-fluent-bit.pkg
+        shell: bash
+        env:
+          URL: ${{ inputs.calyptia-lts-repo }}/macos/${{ inputs.calyptia-lts-version }}/calyptia-fluent-bit-${{ inputs.calyptia-lts-version }}-${{ steps.pkgarch.outputs.brand }}.pkg
+
+      - name: Install Calyptia Fluent Bit LTS Package
+        id: pkginstall
+        run: |
+          installer -pkg /tmp/fluent-bit/calyptia-fluent-bit.pkg -target CurrentUserHomeDirectory
           # pkgutil --lsbom io.fluentbit.calyptia-fluent-bit.binary --volume $HOME
           echo "bin=${HOME}/./usr/local/bin/calyptia-fluent-bit" >> "${GITHUB_OUTPUT}"
+        shell: bash
 
       - name: Install CLI
         uses: engineerd/configurator@v0.0.10
@@ -220,12 +243,18 @@ jobs:
           urlTemplate: https://github.com/calyptia/cli/releases/download/v{{ version }}/cli_{{ rawVersion }}_darwin_${{ steps.pkgarch.outputs.arch }}.tar.gz
           pathInArchive: calyptia
 
-      - name: Checkout the Code
-        uses: actions/checkout@v4
-        with:
-          repository: calyptia/cloud-e2e
-          ref: ${{ inputs.ref }}
-          token: ${{ secrets.github-token }}
+      - name: Test version of Fluent Bit
+        run: |
+          calyptia-fluent-bit --version
+          calyptia-fluent-bit --help
+        shell: bash
+        timeout-minutes: 1
+
+      - name: Test version of CLI
+        run: calyptia version
+        shell: bash
+        timeout-minutes: 1
+
       - name: Run bats tests
         shell: bash
         run: |

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -195,9 +195,8 @@ jobs:
       - name: Set Architecture Package according to runner
         id: pkgarch
         run: |
-          echo -n "Runner architecture: "
-          uname -m
-          if [ "$(uname -m)" == "arm64" ]; then
+          echo "Runner architecture: $(uname -m)"
+          if [[ "$(uname -m)" == "arm64" ]]; then
             echo "Detected Apple Silicon"
             echo "brand=apple" >> "${GITHUB_OUTPUT}"
             echo "arch=arm64" >> "${GITHUB_OUTPUT}"
@@ -212,21 +211,21 @@ jobs:
         if: ${{ inputs.calyptia-package-artefact }}
         uses: actions/download-artifact@v3
         with:
-          name: ${{ inputs.calyptia-package-artefact }}
-          path: /tmp/fluent-bit
+          name: ${{ inputs.calyptia-package-artefact }}-${{ steps.pkgarch.outputs.brand }}
 
       - name: Download and Install Calyptia FluentBit LTS Package
         if: inputs.calyptia-lts-version != ''
         run: |
-          wget "${URL}" -O /tmp/fluent-bit/calyptia-fluent-bit.pkg
+          wget "${URL}" -O calyptia-fluent-bit.pkg
         shell: bash
         env:
           URL: ${{ inputs.calyptia-lts-repo }}/macos/${{ inputs.calyptia-lts-version }}/calyptia-fluent-bit-${{ inputs.calyptia-lts-version }}-${{ steps.pkgarch.outputs.brand }}.pkg
 
+      # Package or artefact are both downloaded to the same place to simplify installation with a single step
       - name: Install Calyptia Fluent Bit LTS Package
         id: pkginstall
         run: |
-          installer -pkg /tmp/fluent-bit/calyptia-fluent-bit.pkg -target CurrentUserHomeDirectory
+          installer -pkg calyptia-fluent-bit.pkg -target CurrentUserHomeDirectory
           # pkgutil --lsbom io.fluentbit.calyptia-fluent-bit.binary --volume $HOME
           echo "bin=${HOME}/./usr/local/bin/calyptia-fluent-bit" >> "${GITHUB_OUTPUT}"
         shell: bash
@@ -261,5 +260,5 @@ jobs:
           ./run-bats.sh ${{ inputs.calyptia-tests }}
         timeout-minutes: 30
         env:
-          TEST_UID: ${{ github.repository }}-${{ github.run_id }}-${{ strategy.job-index }}
+          TEST_UID: ${{ github.repository }}-${{ github.run_id }}-mac-fleet
           FLUENTBIT_BIN: ${{ steps.pkginstall.outputs.bin }}

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -93,7 +93,6 @@ jobs:
       # TODO: install from LTS repo: https://github.com/marketplace/actions/engineerd-configurator
 
       - name: Download Fluent-Bit Binary from Artefact
-        id: download
         if: ${{ inputs.calyptia-package-artefact }}
         uses: actions/download-artifact@v3
         with:
@@ -102,21 +101,31 @@ jobs:
 
       - name: Transform Download Path to MSYS2
         if: ${{ inputs.calyptia-package-artefact }}
-        shell: bash
         # transform download-path into msys2 equivalent
         run: |
             DP="/tmp/fluent-bit"
             DP=$(echo $DP | sed 's/\([A-Za-z]\)\:/\l\1/' | sed 's/\\/\//g')
             mv "/${DP}/"*.zip /tmp/calyptia-fluent-bit.zip
+        shell: bash
 
       - name: Unzip Calyptia Package
         if: ${{ inputs.calyptia-package-artefact }}
-        shell: bash
-        id: pkginstall
         run: |
           unzip /tmp/calyptia-fluent-bit.zip -d /tmp
           mv /tmp/calyptia-fluent-bit-* /tmp/calyptia-fluent-bit
           echo "bin=/tmp/calyptia-fluent-bit/bin/calyptia-fluent-bit" >> "${GITHUB_OUTPUT}"
+        shell: bash
+
+      - name: Grab uploaded Fluent Bit binary
+        if: ${{ inputs.calyptia-lts-version != '' }}
+        uses: engineerd/configurator@v0.0.10
+        with:
+          name: calyptia-fluent-bit
+          version: ${{ inputs.calyptia-lts-version }}
+          fromGitHubReleases: false
+          # e.g. https://calyptia-lts-staging-standard.s3.amazonaws.com/windows/23.4.9/calyptia-fluent-bit-23.4.9-win64.zip
+          urlTemplate: ${{ inputs.calyptia-lts-repo }}/windows/${{ inputs.calyptia-lts-version }}/calyptia-fluent-bit-${{ inputs.calyptia-lts-version }}-win64.zip
+          pathInArchive: calyptia-fluent-bit-.exe
 
       - name: Install CLI
         uses: engineerd/configurator@v0.0.10
@@ -141,10 +150,10 @@ jobs:
         run: |
           ./run-bats.sh ${{ inputs.calyptia-tests }}
         shell: bash
-        timeout-minutes: 30
+        timeout-minutes: 40
         env:
-          TEST_UID: ${{ github.repository }}-${{ github.run_id }}-${{ strategy.job-index }}
-          FLUENTBIT_BIN: /tmp/calyptia-fluent-bit/bin/calyptia-fluent-bit
+          TEST_UID: ${{ github.repository }}-${{ github.run_id }}-win-fleet
+          FLUENTBIT_BIN: calyptia-fluent-bit
 
   run-integration-tests-macos:
     if: contains(inputs.runner, 'macos')

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -130,7 +130,7 @@ jobs:
           fromGitHubReleases: false
           # e.g. https://calyptia-lts-staging-standard.s3.amazonaws.com/windows/23.4.9/calyptia-fluent-bit-23.4.9-win64.zip
           url: ${{ inputs.calyptia-lts-repo }}/windows/${{ inputs.calyptia-lts-version }}/calyptia-fluent-bit-${{ inputs.calyptia-lts-version }}-win64.zip
-          pathInArchive: calyptia-fluent-bit-.exe
+          pathInArchive: calyptia-fluent-bit-${{ inputs.calyptia-lts-version }}-win64/bin/calyptia-fluent-bit.exe
 
       - name: Install CLI
         uses: engineerd/configurator@v0.0.10

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -132,6 +132,13 @@ jobs:
           url: ${{ inputs.calyptia-lts-repo }}/windows/${{ inputs.calyptia-lts-version }}/calyptia-fluent-bit-${{ inputs.calyptia-lts-version }}-win64.zip
           pathInArchive: calyptia-fluent-bit-${{ inputs.calyptia-lts-version }}-win64/bin/calyptia-fluent-bit.exe
 
+      - name: Test version of Fluent Bit
+        run: |
+          calyptia-fluent-bit --version
+          calyptia-fluent-bit --help
+        shell: bash
+        timeout-minutes: 1
+
       - name: Install CLI
         uses: engineerd/configurator@v0.0.10
         with:
@@ -143,6 +150,11 @@ jobs:
           token: ${{ secrets.github-token }}
           urlTemplate: https://github.com/calyptia/cli/releases/download/{{ version }}/cli_{{ rawVersion }}_windows_amd64.tar.gz
           pathInArchive: calyptia.exe
+
+      - name: Test version of CLI
+        run: calyptia version
+        shell: bash
+        timeout-minutes: 1
 
       - name: Run bats tests
         run: |

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -239,7 +239,7 @@ jobs:
           includePrereleases: false
           repo: calyptia/cli
           token: ${{ secrets.github-token }}
-          urlTemplate: https://github.com/calyptia/cli/releases/download/v{{ version }}/cli_{{ rawVersion }}_darwin_${{ steps.pkgarch.outputs.arch }}.tar.gz
+          urlTemplate: https://github.com/calyptia/cli/releases/download/{{ version }}/cli_{{ rawVersion }}_darwin_${{ steps.pkgarch.outputs.arch }}.tar.gz
           pathInArchive: calyptia
 
       - name: Test version of Fluent Bit

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -77,6 +77,13 @@ jobs:
     needs:
       - verify-inputs
     steps:
+      - name: Checkout the Code
+        uses: actions/checkout@v4
+        with:
+          repository: calyptia/cloud-e2e
+          ref: ${{ inputs.ref }}
+          token: ${{ secrets.github-token }}
+
       # missing: lsof, parallel, bc
       - name: Install dependencies
         run: |
@@ -89,8 +96,6 @@ jobs:
         uses: mig4/setup-bats@v1
         with:
           bats-version: 1.10.0
-
-      # TODO: install from LTS repo: https://github.com/marketplace/actions/engineerd-configurator
 
       - name: Download Fluent-Bit Binary from Artefact
         if: ${{ inputs.calyptia-package-artefact }}
@@ -124,7 +129,7 @@ jobs:
           version: ${{ inputs.calyptia-lts-version }}
           fromGitHubReleases: false
           # e.g. https://calyptia-lts-staging-standard.s3.amazonaws.com/windows/23.4.9/calyptia-fluent-bit-23.4.9-win64.zip
-          urlTemplate: ${{ inputs.calyptia-lts-repo }}/windows/${{ inputs.calyptia-lts-version }}/calyptia-fluent-bit-${{ inputs.calyptia-lts-version }}-win64.zip
+          url: ${{ inputs.calyptia-lts-repo }}/windows/${{ inputs.calyptia-lts-version }}/calyptia-fluent-bit-${{ inputs.calyptia-lts-version }}-win64.zip
           pathInArchive: calyptia-fluent-bit-.exe
 
       - name: Install CLI
@@ -138,13 +143,6 @@ jobs:
           token: ${{ secrets.github-token }}
           urlTemplate: https://github.com/calyptia/cli/releases/download/{{ version }}/cli_{{ rawVersion }}_windows_amd64.tar.gz
           pathInArchive: calyptia.exe
-
-      - name: Checkout the Code
-        uses: actions/checkout@v4
-        with:
-          repository: calyptia/cloud-e2e
-          ref: ${{ inputs.ref }}
-          token: ${{ secrets.github-token }}
 
       - name: Run bats tests
         run: |

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -244,10 +244,12 @@ jobs:
 
       - name: Test version of Fluent Bit
         run: |
-          calyptia-fluent-bit --version
-          calyptia-fluent-bit --help
+          $FLUENTBIT_BIN --version
+          $FLUENTBIT_BIN --help
         shell: bash
         timeout-minutes: 1
+        env:
+          FLUENTBIT_BIN: ${{ steps.pkginstall.outputs.bin }}
 
       - name: Test version of CLI
         run: calyptia version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,27 +58,26 @@ jobs:
       google-access-key: ${{ secrets.GCP_SA_KEY }}
       github-token: ${{ secrets.CI_PAT }}
 
-  # TODO: add fleet tests once ready
-  # ci-fleet-tests:
-  #   uses: ./.github/workflows/call-fleet-integration-tests.yaml
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       testset:
-  #         - fleet/cli
-  #       runner:
-  #         - macos-latest
-  #         - windows-latest
-  #   with:
-  #     calyptia-tests: "${{ matrix.testset }}/"
-  #     calyptia-lts-version: 23.10.2
-  #     runner: "${{ matrix.runner }}"
-  #     # # update to main when changes have been merged
-  #     # ref: pwhelan-fleet-e2e
-  #     calyptia-cloud-url: "https://cloud-api-dev.calyptia.com"
-  #   secrets:
-  #     github-token: ${{ secrets.CI_PAT }}
-  #     calyptia-cloud-token: ${{ secrets.CALYPTIA_CLOUD_TOKEN }}
+  ci-fleet-tests:
+    uses: ./.github/workflows/call-fleet-integration-tests.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        testset:
+          - fleet/cli
+        runner:
+          # - macos-latest
+          - windows-latest
+    with:
+      calyptia-tests: "${{ matrix.testset }}/"
+      calyptia-lts-version: 23.10.2
+      runner: "${{ matrix.runner }}"
+      # TODO: update to main when changes have been merged
+      ref: pwhelan-fleet-e2e
+      calyptia-cloud-url: "https://cloud-api-dev.calyptia.com"
+    secrets:
+      github-token: ${{ secrets.CI_PAT }}
+      calyptia-cloud-token: ${{ secrets.CALYPTIA_CLOUD_TOKEN }}
 
   ci-generate-reports:
     name: Generate SBOM and CVE reports for release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
       github-token: ${{ secrets.CI_PAT }}
 
   ci-fleet-tests:
+    if: contains(github.event.pull_request.labels.*.name, 'enable-fleet-tests')
     uses: ./.github/workflows/call-fleet-integration-tests.yaml
     strategy:
       fail-fast: false
@@ -67,7 +68,7 @@ jobs:
         testset:
           - fleet/cli
         runner:
-          # - macos-latest
+          - macos-latest
           - windows-latest
     with:
       calyptia-tests: "${{ matrix.testset }}/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     uses: ./.github/workflows/get-versions.yaml
 
   ci-e2e-tests:
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'disable-e2e-tests') }}
     needs:
       - ci-get-metadata
     # We cannot run this from a public repo as the cloud-e2e repo is private so even though it shares workflows with the Calyptia org,


### PR DESCRIPTION
Add basic Fleet testing to CI workflows for Windows and macOS.

Tests are failing, primarily though this is around ensuring the binaries are valid and repo is checked out.