### PR TITLE
workflows: add self-hosted stack VM creation

### DIFF
--- a/.github/actions/debug-cluster/action.yaml
+++ b/.github/actions/debug-cluster/action.yaml
@@ -1,0 +1,95 @@
+name: Composite action to debug cluster
+runs:
+  using: composite
+  steps:
+      - name: helm releases
+        continue-on-error: true
+        if: always()
+        run: |
+          helm list -A || true
+          echo '-------------------------------------------------------------------------------'
+        shell: bash
+
+      - name: simple debug cluster
+        continue-on-error: true
+        if: always()
+        run: |
+          kubectl get pods --all-namespaces || true
+          echo '-------------------------------------------------------------------------------'
+          kubectl describe pods --namespace "$CALYPTIA_NAMESPACE" || true
+          echo '-------------------------------------------------------------------------------'
+          kubectl cluster-info dump --all-namespaces || true
+          echo '-------------------------------------------------------------------------------'
+        shell: bash
+
+      - name: get token
+        continue-on-error: true
+        if: always()
+        run: |
+          kubectl get secrets -A || true
+          echo '-------------------------------------------------------------------------------'
+          kubectl get secret -n "$CALYPTIA_NAMESPACE" auth-secret -o jsonpath='{.data.token}'| base64 --decode
+          echo '-------------------------------------------------------------------------------'
+        shell: bash
+
+      - name: get pipelines
+        continue-on-error: true
+        if: always()
+        run: |
+          kubectl get pipeline -A || true
+          echo '-------------------------------------------------------------------------------'
+        shell: bash
+
+      - name: cluster dump
+        continue-on-error: true
+        if: always()
+        run: |
+          kubectl cluster-dump -A || true
+        shell: bash
+
+      - name: full debug cluster
+        continue-on-error: true
+        if: always()
+        run: |
+          kubectl cluster-info || true
+          echo '-------------------------------------------------------------------------------'
+          kubectl describe all -n "$CALYPTIA_NAMESPACE" || true
+          echo '-------------------------------------------------------------------------------'
+          kubectl get secrets -n "$CALYPTIA_NAMESPACE" || true
+          echo '-------------------------------------------------------------------------------'
+          kubectl describe serviceaccount default -n "$CALYPTIA_NAMESPACE" || true
+          echo '-------------------------------------------------------------------------------'
+          kubectl describe -n "$CALYPTIA_NAMESPACE" deployment/cloud-api || true
+          echo '-------------------------------------------------------------------------------'
+          kubectl logs -n "$CALYPTIA_NAMESPACE" deployment/cloud-api || true
+          echo '-------------------------------------------------------------------------------'
+          kubectl describe -n "$CALYPTIA_NAMESPACE" deployment/core || true
+          echo '-------------------------------------------------------------------------------'
+          kubectl logs -n "$CALYPTIA_NAMESPACE" deployment/core || true
+          echo '-------------------------------------------------------------------------------'
+          kubectl describe -n "$CALYPTIA_NAMESPACE" deployment/postgres || true
+          echo '-------------------------------------------------------------------------------'
+          kubectl logs -n "$CALYPTIA_NAMESPACE" deployment/postgres || true
+          echo '-------------------------------------------------------------------------------'
+          kubectl describe -n "$CALYPTIA_NAMESPACE" deployment/influxdb || true
+          echo '-------------------------------------------------------------------------------'
+          kubectl logs -n "$CALYPTIA_NAMESPACE" deployment/influxdb || true
+          echo '-------------------------------------------------------------------------------'
+          kubectl describe all -n "ingress-nginx" || true
+          echo '-------------------------------------------------------------------------------'
+        shell: bash
+
+      - name: list images in cluster
+        # Useful to ensure we grab everything
+        continue-on-error: true
+        if: always()
+        # https://kubernetes.io/docs/tasks/access-application-cluster/list-all-running-container-images/
+        run: |
+          docker images
+          echo '-------------------------------------------------------------------------------'
+          kubectl get pods --all-namespaces -o jsonpath="{.items[*].spec.containers[*].image}" |\
+            tr -s '[[:space:]]' '\n' |\
+            sort |\
+            uniq -c
+          echo '-------------------------------------------------------------------------------'
+        shell: bash

--- a/.github/workflows/call-create-self-hosted-stack.yaml
+++ b/.github/workflows/call-create-self-hosted-stack.yaml
@@ -1,0 +1,205 @@
+name: Reusable workflow to create a new self-hosted stack
+on:
+    workflow_call:
+        inputs:
+            ref:
+                description: The commit, tag or branch of this repository to check out.
+                type: string
+                required: false
+                default: main
+            zone:
+                description: The GCP zone to use.
+                type: string
+                required: false
+                default: us-east1-c
+            project:
+                description: The GCP project to use.
+                type: string
+                required: false
+                default: calyptia-playground-371615
+            firewall-rule:
+                description: The name of the firewall rule for traffic and matching tag on the instance.
+                type: string
+                default: cloud-api-server
+                required: false
+            network:
+                description: The GCP network to allow ingress for.
+                type: string
+                required: false
+                default: default
+            use-released-chart:
+                description: Whether to use the local checked out chart or the one in the repository.
+                type: boolean
+                required: false
+                default: true
+            self-hosted-chart-ref:
+                description: If not using the released chart then the ref to use for the development one.
+                type: string
+                required: false
+                default: main
+        secrets:
+            token:
+                description: The Github PAT used to checkout and also as a pull secret for registry access.
+                required: true
+            gcp-credentials:
+                description: The GCP SA credentials to create the VM.
+                required: true
+        outputs:
+            calyptia-cloud-url:
+                description: The URL to connect to for Calyptia Cloud self-hosted stack.
+                value: ${{ jobs.create-gcp-stack.outputs.cloud-url }}
+            calyptia-cloud-token:
+                description: The authentication token for Calyptia Cloud self-hosted stack.
+                value: ${{ jobs.create-gcp-stack.outputs.cloud-token }}
+            calyptia-cloud-vm-name:
+                description: The name of the GCP VM created for cleanup later.
+                value: ${{ jobs.create-gcp-stack.outputs.vm-name }}
+jobs:
+    create-gcp-stack:
+        name: Spin up GCP VM with self-hosted stack
+        runs-on: ubuntu-latest
+        env:
+            VM_NAME: ci-self-hosted-stack-${{ github.run_id }}
+            VM_DESCRIPTION: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        outputs:
+            cloud-token: ${{ steps.get-cloud-token.outputs.token }}
+            cloud-url: ${{ steps.get-ip-address.outputs.url }}
+            vm-name: ${{ env.VM_NAME }}
+            KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+        steps:
+            - name: Checkout self-hosted chart repo
+              uses: actions/checkout@v4
+              with:
+                repository: calyptia/core-product-release
+                ref: ${{ inputs.ref }}
+                token: ${{ secrets.token }}
+
+            - id: 'auth'
+              uses: 'google-github-actions/auth@v2'
+              with:
+                credentials_json: ${{ secrets.gcp-credentials }}
+
+            - name: 'Set up Cloud SDK'
+              uses: 'google-github-actions/setup-gcloud@v1'
+
+            - name: Set up defaults
+              run: |
+                gcloud config set compute/zone '${{ inputs.zone }}'
+                gcloud config set project '${{ inputs.project }}'
+                gcloud info
+              shell: bash
+
+            - name: Create GCP VM
+              timeout-minutes: 5
+              run: ./scripts/create-self-hosted-gcp-vm.sh
+              shell: bash
+
+            - name: Set up ingress rule for traffic if not present
+              run: |
+                gcloud compute instances add-tags "$VM_NAME" --tags='${{ inputs.firewall-rule }}'
+                if gcloud compute firewall-rules describe '${{ inputs.firewall-rule }}' ; then
+                  echo "Firewall rule already in place"
+                  gcloud compute firewall-rules update '${{ inputs.firewall-rule }}' --allow tcp:5000 \
+                    --source-tags='${{ inputs.firewall-rule }}' --source-ranges=0.0.0.0/0
+                else
+                  gcloud compute firewall-rules create '${{ inputs.firewall-rule }}' --allow tcp:5000 \
+                    --source-tags='${{ inputs.firewall-rule }}' --source-ranges=0.0.0.0/0 \
+                    --description="Cloud API traffic" --network="${{ inputs.network }}" --direction=INGRESS
+                fi
+              shell: bash
+
+            - name: Install k3s
+              timeout-minutes: 10
+              run: |
+                gcloud compute ssh "$VM_NAME" -q --command="curl -sSfL https://get.k3s.io/ | sh -s - --write-kubeconfig-mode 644 --prefer-bundled-bin"
+                gcloud compute ssh "$VM_NAME" -q --command="until k3s kubectl get pods -A; do sleep 10; done"
+              shell: bash
+
+            - name: Install helm
+              timeout-minutes: 5
+              run: |
+                gcloud compute ssh "$VM_NAME" -q --command="curl -sSfL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash"
+              shell: bash
+
+            - name: Install self-hosted from release repo
+              if: inputs.use-released-chart
+              timeout-minutes: 6
+              run: |
+                gcloud compute ssh "$VM_NAME" -q --command="helm repo add calyptia https://helm.calyptia.com --force-update"
+                gcloud compute ssh "$VM_NAME" -q --command="helm repo update"
+                gcloud compute ssh "$VM_NAME" -q --command="export KUBECONFIG=/etc/rancher/k3s/k3s.yaml;helm upgrade --install \
+                    --create-namespace --namespace calyptia \
+                    --set imageCredentials.secretName=regcreds \
+                    --set imageCredentials.registry=ghcr.io \
+                    --set imageCredentials.username='${{ github.actor }}' \
+                    --set imageCredentials.password='${{ secrets.token }}' \
+                    --set imageCredentials.email='ci@calyptia.com' \
+                    --set global.pullPolicy=IfNotPresent \
+                    --set vivo.enabled=false \
+                    --set frontend.enabled=false \
+                    --set operator.enabled=false \
+                    --wait --debug \
+                    calyptia-cloud calyptia/calyptia-standalone"
+              shell: bash
+
+            - name: Checkout self-hosted chart repo
+              if: ${{ ! inputs.use-released-chart }}
+              uses: actions/checkout@v4
+              with:
+                repository: calyptia/chart-cloud-standalone
+                ref: ${{ inputs.self-hosted-chart-ref }}
+                token: ${{ secrets.token }}
+                path: local-self-hosted/
+
+            - name: Install self-hosted from local repo
+              if: ${{ ! inputs.use-released-chart }}
+              timeout-minutes: 6
+              run: |
+                gcloud compute ssh "$VM_NAME" -q --command="export KUBECONFIG=/etc/rancher/k3s/k3s.yaml;helm upgrade --install \
+                    --create-namespace --namespace calyptia \
+                    --set imageCredentials.secretName=regcreds \
+                    --set imageCredentials.registry=ghcr.io \
+                    --set imageCredentials.username='${{ github.actor }}' \
+                    --set imageCredentials.password='${{ secrets.token }}' \
+                    --set imageCredentials.email='ci@calyptia.com' \
+                    --set global.pullPolicy=IfNotPresent \
+                    --set vivo.enabled=false \
+                    --set frontend.enabled=false \
+                    --set operator.enabled=false \
+                    --wait --debug \
+                    ./chart calyptia/calyptia-standalone"
+              shell: bash
+
+            - name: Get cloud token
+              id: get-cloud-token
+              run: |
+                TOKEN=$(gcloud compute ssh "$VM_NAME" -q --command="k3s kubectl get secret -n calyptia auth-secret -o jsonpath='{.data.token}'| base64 --decode")
+                echo "token=$TOKEN"
+                echo "token=$TOKEN" >> $GITHUB_OUTPUT
+              shell: bash
+
+            - name: Get IP address
+              id: get-ip-address
+              run: |
+                INTERNAL_IP=$(gcloud compute instances describe "$VM_NAME" --format='get(networkInterfaces[0].networkIP)')
+                echo "internal=$INTERNAL_IP"
+                echo "internal=$INTERNAL_IP" >> $GITHUB_OUTPUT
+
+                EXTERNAL_IP=$(gcloud compute instances describe "$VM_NAME" --format='get(networkInterfaces[0].accessConfigs[0].natIP)')
+                echo "external=$EXTERNAL_IP"
+                echo "external=$EXTERNAL_IP" >> $GITHUB_OUTPUT
+
+                EXTERNAL_URL="http://${EXTERNAL_IP}:5000"
+                echo "url=$EXTERNAL_URL"
+                echo "url=$EXTERNAL_URL" >> $GITHUB_OUTPUT
+              shell: bash
+
+            - name: Debug
+              if: always()
+              continue-on-error: true
+              run: |
+                gcloud compute ssh "$VM_NAME" -q --command='journalctl -u k3s' || true
+                gcloud compute ssh "$VM_NAME" -q --command='k3s kubectl get pods --all-namespaces' || true
+                gcloud compute firewall-rules list || true
+                curl -sSfL "${{ steps.get-ip-address.outputs.url }}" || true
+              shell: bash

--- a/.github/workflows/call-delete-self-hosted-stack.yaml
+++ b/.github/workflows/call-delete-self-hosted-stack.yaml
@@ -1,0 +1,45 @@
+name: Reusable workflow to delete a self-hosted stack
+on:
+    workflow_call:
+        inputs:
+            calyptia-cloud-vm-name:
+              description: The name of the GCP VM to remove.
+              required: true
+              type: string
+            zone:
+                description: The GCP zone to use.
+                type: string
+                required: false
+                default: us-east1-c
+            project:
+                description: The GCP project to use.
+                type: string
+                required: false
+                default: calyptia-playground-371615
+        secrets:
+            gcp-credentials:
+                description: The GCP SA credentials to create the VM.
+                required: true
+jobs:
+    delete-gcp-stack:
+        name: Delete GCP VM with self-hosted stack
+        runs-on: ubuntu-latest
+        steps:
+            - id: 'auth'
+              uses: 'google-github-actions/auth@v2'
+              with:
+                credentials_json: ${{ secrets.gcp-credentials }}
+
+            - name: 'Set up Cloud SDK'
+              uses: 'google-github-actions/setup-gcloud@v1'
+
+            - name: Set up defaults
+              run: |
+                gcloud config set compute/zone '${{ inputs.zone }}'
+                gcloud config set project '${{ inputs.project }}'
+                gcloud info
+              shell: bash
+
+            - name: Delete GCP VM
+              run: gcloud compute instances delete "${{ inputs.calyptia-cloud-vm-name }}" -q 2>/dev/null || true
+              shell: bash

--- a/.github/workflows/create-self-hosted-stack.yaml
+++ b/.github/workflows/create-self-hosted-stack.yaml
@@ -1,0 +1,81 @@
+name: Create a test self-hosted stack
+on:
+    workflow_dispatch:
+jobs:
+    create-vm:
+        name: Create VM
+        uses: ./.github/workflows/call-create-self-hosted-stack.yaml
+        secrets:
+            token: ${{ secrets.CI_PAT }}
+            gcp-credentials: ${{ secrets.GCP_PLAYGROUND_SA }}
+
+    run-api-tests:
+        name: Run API tests against cloud API server
+        runs-on: ubuntu-latest
+        needs:
+            - create-vm
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                repository: calyptia/api
+
+            - name: API schema tests
+              run: |
+                  ./scripts/run-tests.sh
+              shell: bash
+              timeout-minutes: 20
+              env:
+                CLOUD_URL: ${{ needs.create-vm.outputs.calyptia-cloud-url }}
+                TOKEN: ${{ needs.create-vm.outputs.calyptia-cloud-token }}
+
+    create-test-instance:
+        name: Create a test instance on the new stack
+        runs-on: ubuntu-latest
+        needs:
+            - create-vm
+        permissions:
+            contents: read
+        env:
+            VM_NAME: ${{ needs.create-vm.outputs.calyptia-cloud-vm-name }}
+            CALYPTIA_CLOUD_URL: ${{ needs.create-vm.outputs.calyptia-cloud-url }}
+            CALYPTIA_CLOUD_TOKEN: ${{ needs.create-vm.outputs.calyptia-cloud-token }}
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Hit the Cloud API endpoint
+              run: curl -sSfL "${CALYPTIA_CLOUD_URL}"
+              shell: bash
+
+            - name: Set up KIND locally to run instance on
+              uses: helm/kind-action@v1.8.0
+              timeout-minutes: 5
+
+            - name: Deploy instance in local cluster
+              timeout-minutes: 5
+              run: |
+                helm repo add calyptia https://helm.calyptia.com --force-update
+                helm repo update
+                helm upgrade --install core-instance calyptia/core-instance \
+                --set cloudToken="${CALYPTIA_CLOUD_TOKEN}" \
+                --set cloudUrl="${CALYPTIA_CLOUD_URL}" \
+                --set coreInstance=test \
+                --debug --wait
+              shell: bash
+
+            - uses: ./.github/actions/debug-cluster/
+              if: always()
+
+    delete-vm:
+        if: always()
+        needs:
+            - create-vm
+            - create-test-instance
+            - run-api-tests
+        name: Clean up stack
+        uses: ./.github/workflows/call-delete-self-hosted-stack.yaml
+        with:
+            calyptia-cloud-vm-name: ${{ needs.create-vm.outputs.calyptia-cloud-vm-name }}
+        secrets:
+            gcp-credentials: ${{ secrets.GCP_PLAYGROUND_SA }}

--- a/scripts/create-self-hosted-gcp-vm.sh
+++ b/scripts/create-self-hosted-gcp-vm.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -eux
+
+function gcp_create_vm() {
+  local vm_name=$1
+  local image=$2
+  local description=${3:-"Created using image: $image_family"}
+
+  # Clean up any existing ones
+  gcloud compute instances delete "$vm_name" -q &>/dev/null || true
+
+  if [[ "$image" == project* ]]; then
+    echo "Creating VM: $vm_name (from $image)"
+    gcloud compute instances create "$vm_name" \
+      --image="$image" \
+      --description="$description" \
+      --machine-type=c2-standard-4 \
+      --boot-disk-size 250GB
+  else
+    # Split around the /
+    local image_project=${image%%/*}
+    local image_family=${image##*/}
+    echo "Creating VM: $vm_name (from $image_family and $image_project)"
+    gcloud compute instances create "$vm_name" \
+      --image-project="$image_project" \
+      --image-family="$image_family" \
+      --image-family-scope=global \
+      --description="$description" \
+      --machine-type=c2-standard-4 \
+      --boot-disk-size 250GB
+  fi
+
+  echo "Waiting for SSH access to $vm_name..."
+  until gcloud compute ssh "$vm_name" -q --command="true" &>/dev/null; do
+      echo -n '.'
+      sleep 10
+  done
+  echo
+  echo "Successfully connected to $vm_name"
+
+  gcloud compute ssh "$vm_name" -q --command='echo "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" | sudo tee -a /etc/environment' &>/dev/null || true
+}
+
+gcp_create_vm "${VM_NAME:-self-hosted-vm}" 'ubuntu-os-cloud/ubuntu-2204-lts' "${VM_DESCRIPTION:-Self hosted stack VM}"


### PR DESCRIPTION
Transfer workflows from private self-hosted chart repo.

These workflows allow you to spin up a GCP VM running k3s with self-hosted control plane deployed - either a released version or a private unreleased version for testing against.

These may be useful for fleet testing or similar.

There is an example workflow to show how to use it - note the VM will stay running until you delete it which can also be useful for debug.