### PR TITLE
workflows: support multiple product updates

### DIFF
--- a/.github/workflows/update-product-version.yaml
+++ b/.github/workflows/update-product-version.yaml
@@ -39,7 +39,7 @@ jobs:
             - name: Sanitise product names
               id: sanitise
               run: |
-                BRANCH=${PRODUCT//,/_}
+                BRANCH=${PRODUCT//\,/_}
                 echo "branch=$BRANCH"
                 echo "branch=$BRANCH" >> GITHUB_OUTPUT
               shell: bash

--- a/.github/workflows/update-product-version.yaml
+++ b/.github/workflows/update-product-version.yaml
@@ -3,11 +3,11 @@ on:
     workflow_call:
         inputs:
             product:
-                description: The JSON key for the product to update.
+                description: The JSON key(s) for the product(s) to update. Comma separated if more than one.
                 required: true
                 type: string
             version:
-                description: The numeric (no v- prefix) version to update to.
+                description: The numeric (no v- prefix) version(s) to update to. Comma separated if more than one and matching index in the product array.
                 required: true
                 type: string
         secrets:
@@ -19,54 +19,39 @@ on:
                 value: ${{ jobs.version-update.outputs.pr || '' }}
                 description: The PR created, if any, or an empty string.
 jobs:
-    version-checks:
-        name: Sanitise and check inputs
-        runs-on: ubuntu-latest
-        outputs:
-            version: ${{ steps.version.outputs.version }}
-            product: ${{ inputs.product }}
-        steps:
-            - uses: actions/checkout@v4
-              with:
-                token: ${{ secrets.token }}
-                repository: calyptia/core-product-release
-
-            - name: Check product exists
-              run: grep -q '${{ inputs.product }}' ./component-config.json
-              shell: bash
-
-            - name: Get numeric version only
-              id: version
-              run: |
-                VERSION=${{ inputs.version }}
-                # Handle stripping the v prefix if present
-                if [[ "$VERSION" =~ ^v?([0-9]+\.[0-9]+\.[0-9]+)$ ]] ; then
-                    VERSION=${BASH_REMATCH[1]}
-                    echo "Valid version string: $VERSION"
-                else
-                    echo "ERROR: Invalid semver string: $VERSION"
-                fi
-                echo "version=$VERSION" >> $GITHUB_OUTPUT
-              shell: bash
-
     version-update:
-        name: Update ${{ needs.version-checks.outputs.product }} to ${{ needs.version-checks.outputs.version }}
+        name: Update versions
         runs-on: ubuntu-latest
-        needs:
-            - version-checks
         outputs:
             pr: ${{ steps.cpr.outputs.pull-request-number || '' }}
         steps:
+            - name: Add dependencies
+              run: |
+                sudo apt-get update
+                sudo apt-get install -y jq
+              shell: bash
+
             - uses: actions/checkout@v4
               with:
                 token: ${{ secrets.token }}
                 repository: calyptia/core-product-release
 
-            - name: Update versions
+            - name: Sanitise product names
+              id: sanitise
               run: |
-                jq '.versions.${{ needs.version-checks.outputs.product }} = "${{ needs.version-checks.outputs.version }}"' ./component-config.json | tee ./component-config-new.json
-                mv -f ./component-config-new.json ./component-config.json
+                BRANCH=${PRODUCT//,/_}
+                echo "branch=$BRANCH"
+                echo "branch=$BRANCH" >> GITHUB_OUTPUT
               shell: bash
+              env:
+                PRODUCT: ${{ inputs.product }}
+
+            - name: Update versions
+              run: ./scripts/update-versions.sh
+              shell: bash
+              env:
+                PRODUCTS: ${{ inputs.product }}
+                VERSIONS: ${{ inputs.version }}
 
             - name: Generate PR - runs all the tests
               id: cpr
@@ -76,7 +61,7 @@ jobs:
                 signoff: true
                 # Repeated calls will sit on top of each other to test as one until merged
                 # Only updates per product
-                branch: ci_update_versions_push_${{ needs.version-checks.outputs.product }}
+                branch: ci_update_versions_push_${{ steps.sanitise.outputs.branch }}
                 delete-branch: true
                 title: 'ci: update to latest Calyptia versions'
                 # We need workflows permission so have to use the CI_PAT
@@ -84,7 +69,7 @@ jobs:
                 labels: ci,automerge
                 body: |
                   Update Calyptia versions
-                  - ${{ needs.version-checks.outputs.product }} = "${{ needs.version-checks.outputs.version }}"
+                  - ${{ inputs.product }} = "${{ inputs.version }}"
 
                   Github info:
                   - Created by ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -eux
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+PRODUCTS=${PRODUCTS:?}
+VERSIONS=${VERSIONS:?}
+
+if ! command -v jq &> /dev/null; then
+    echo "ERROR: missing jq command, please install"
+    exit 1
+fi
+
+rm -f "$SCRIPT_DIR/component-config-new.json"
+
+# Either a single entry or a comma-separate list
+IFS=', ' read -r -a products <<< "$PRODUCTS"
+IFS=', ' read -r -a versions <<< "$VERSIONS"
+
+# Check we have a matching set of arrays
+if [[ "${#products[@]}" -ne "${#versions[@]}" ]]; then
+    echo "Mismatch in product vs version sizes (${#products[@]} != ${#versions[@]})"
+    exit 1
+fi
+
+# Iterate over each entry to confirm it is valid and then update product=version
+for index in "${!products[@]}"; do
+    product="${products[index]}"
+    version="${versions[index]}"
+
+    echo "Updating $product=$version"
+
+    # Does the product exist?
+    if ! grep -q "$product" ./component-config.json; then
+        echo "Missing $product"
+        exit 1
+    fi
+
+    # Do we have an actual version?
+    if [[ -z "$version" ]]; then
+        echo "Missing version for $product at index $index"
+        exit 1
+    fi
+
+    # Strip any v's and ensure this is semver-compatible
+    if [[ "$version" =~ ^v?([0-9]+\.[0-9]+\.[0-9]+)$ ]] ; then
+        version=${BASH_REMATCH[1]}
+        echo "$product = $version"
+    else
+        echo "ERROR: Invalid semver string ($product): $version"
+        exit 1
+    fi
+
+    # Update the new file
+    jq ".versions.$product = \"$version\"" "$SCRIPT_DIR/component-config.json" | tee "$SCRIPT_DIR/component-config-new.json"
+done
+
+mv -f "$SCRIPT_DIR/component-config-new.json" "$SCRIPT_DIR/component-config.json"
+cat "$SCRIPT_DIR/component-config.json"

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -52,7 +52,7 @@ for index in "${!products[@]}"; do
 
     # Update the new file
     jq ".versions.$product = \"$version\"" "$SCRIPT_DIR/../component-config.json" | tee "$SCRIPT_DIR/../component-config-new.json"
+    mv -f "$SCRIPT_DIR/../component-config-new.json" "$SCRIPT_DIR/../component-config.json"
 done
 
-mv -f "$SCRIPT_DIR/../component-config-new.json" "$SCRIPT_DIR/../component-config.json"
 cat "$SCRIPT_DIR/../component-config.json"

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -30,7 +30,7 @@ for index in "${!products[@]}"; do
     echo "Updating $product=$version"
 
     # Does the product exist?
-    if ! grep -q "$product" ./component-config.json; then
+    if ! grep -q "$product" "$SCRIPT_DIR/../component-config.json"; then
         echo "Missing $product"
         exit 1
     fi
@@ -51,8 +51,8 @@ for index in "${!products[@]}"; do
     fi
 
     # Update the new file
-    jq ".versions.$product = \"$version\"" "$SCRIPT_DIR/component-config.json" | tee "$SCRIPT_DIR/component-config-new.json"
+    jq ".versions.$product = \"$version\"" "$SCRIPT_DIR/../component-config.json" | tee "$SCRIPT_DIR/../component-config-new.json"
 done
 
-mv -f "$SCRIPT_DIR/component-config-new.json" "$SCRIPT_DIR/component-config.json"
-cat "$SCRIPT_DIR/component-config.json"
+mv -f "$SCRIPT_DIR/../component-config-new.json" "$SCRIPT_DIR/../component-config.json"
+cat "$SCRIPT_DIR/../component-config.json"

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -51,6 +51,7 @@ for index in "${!products[@]}"; do
     fi
 
     # Update the new file
+    rm -f "$SCRIPT_DIR/component-config-new.json"
     jq ".versions.$product = \"$version\"" "$SCRIPT_DIR/../component-config.json" | tee "$SCRIPT_DIR/../component-config-new.json"
     mv -f "$SCRIPT_DIR/../component-config-new.json" "$SCRIPT_DIR/../component-config.json"
 done


### PR DESCRIPTION
Groundwork for supporting multi-product update through single PR.

Part of work for https://app.asana.com/0/1204881426070801/1206158278987937/f

# Testing

1. Invalid arrays
```shell
$ export PRODUCTS="core_fluent_bit,core_operator"
$ export VERSIONS="1.2.3"
$ ./scripts/update-versions.sh
...
+ echo 'Mismatch in product vs version sizes (2 != 1)'
Mismatch in product vs version sizes (2 != 1)
+ exit 1
$ export VERSIONS="1.2.3,4.5.6,7.8.9"
$ ./scripts/update-versions.sh
...
+ echo 'Mismatch in product vs version sizes (2 != 3)'
Mismatch in product vs version sizes (2 != 3)
+ exit 1
$ export VERSIONS="1.2.3,4.5.6"
$ ./scripts/update-versions.sh
...
+ cat /home/pat/github/calyptia/core-product-release/scripts/../component-config.json
{
  "versions": {
    "cli": "1.12.1",
    "cloud": "1.6.8",
    "cloud_e2e": "1.6.5",
    "core_fluent_bit": "1.2.3",
    "core": "1.4.0",
    "core_operator": "4.5.6",
    "configmap_reload": "0.11.1",
    "core_sidecar_ingest_check": "0.0.7",
    "frontend": "1.5.4",
    "lua_sandbox": "2.2.0",
    "lua_modules": "5.0.1"
  },
  "k8s_kind_versions": [
    "v1.27.3",
    "v1.25.11",
    "v1.23.17"
  ],
  "k8s_k3s_versions": [
    "v1.27.7-k3s2",
    "v1.25.15-k3s2",
    "v1.23.17-k3s1"
  ]
}
```
2. Multiple values
```shell
$ export PRODUCTS="core_fluent_bit,core_operator"
$ export VERSIONS="1.2.3,4.5.6"
$ ./scripts/update-versions.sh
...
+ cat /home/pat/github/calyptia/core-product-release/scripts/../component-config.json
{
  "versions": {
    "cli": "1.12.1",
    "cloud": "1.6.8",
    "cloud_e2e": "1.6.5",
    "core_fluent_bit": "1.2.3",
    "core": "1.4.0",
    "core_operator": "4.5.6",
...
```
3. Single values
```shell
$ export PRODUCTS="core_fluent_bit"
$ export VERSIONS="7.8.9"
$ ./scripts/update-versions.sh
...
+ cat /home/pat/github/calyptia/core-product-release/scripts/../component-config.json
{
  "versions": {
    "cli": "1.12.1",
    "cloud": "1.6.8",
    "cloud_e2e": "1.6.5",
    "core_fluent_bit": "7.8.9",
    "core": "1.4.0",
    "core_operator": "2.2.0",
    "configmap_reload": "0.11.1",
    "core_sidecar_ingest_check": "0.0.7",
    "frontend": "1.5.4",
    "lua_sandbox": "2.2.0",
    "lua_modules": "5.0.1"
  },
...
```
4. Semver versions in values
```shell
$ export PRODUCTS="core_fluent_bit,core_operator"
$ export VERSIONS="1.2.3,v4.5.6"
$ ./scripts/update-versions.sh
...
+ version=v4.5.6
+ echo 'Updating core_operator=v4.5.6'
Updating core_operator=v4.5.6
+ grep -q core_operator /home/pat/github/calyptia/core-product-release/scripts/../component-config.json
+ [[ -z v4.5.6 ]]
+ [[ v4.5.6 =~ ^v?([0-9]+\.[0-9]+\.[0-9]+)$ ]]
+ version=4.5.6
+ echo 'core_operator = 4.5.6'
core_operator = 4.5.6
+ rm -f /home/pat/github/calyptia/core-product-release/scripts/component-config-new.json
+ jq '.versions.core_operator = "4.5.6"' /home/pat/github/calyptia/core-product-release/scripts/../component-config.json
+ tee /home/pat/github/calyptia/core-product-release/scripts/../component-config-new.json
{
  "versions": {
    "cli": "1.12.1",
    "cloud": "1.6.8",
    "cloud_e2e": "1.6.5",
    "core_fluent_bit": "1.2.3",
    "core": "1.4.0",
    "core_operator": "4.5.6",
...
```