### PR TITLE
fix: remove extra slash at front of zip path for artifcat.

### DIFF
--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -110,7 +110,7 @@ jobs:
         run: |
           DP="/tmp/fluent-bit"
           DP=$(echo $DP | sed 's/\([A-Za-z]\)\:/\l\1/' | sed 's/\\/\//g')
-          mv "/${DP}/"*.zip /tmp/calyptia-fluent-bit.zip
+          mv "${DP}/"*.zip /tmp/calyptia-fluent-bit.zip
         shell: bash
 
       - name: Unzip Calyptia Package


### PR DESCRIPTION
This branch aims to fix the following [error](https://github.com/calyptia/calyptia-fluent-bit/actions/runs/7449741325/job/20269696759#step:7:1):

```
Run DP="/tmp/fluent-bit"
  DP="/tmp/fluent-bit"
  DP=$(echo $DP | sed 's/\([A-Za-z]\)\:/\l\[1](https://github.com/calyptia/calyptia-fluent-bit/actions/runs/7449741325/job/20269696759#step:7:1)/' | sed 's/\\/\//g')
  mv "/${DP}/"*.zip /tmp/calyptia-fluent-bit.zip
  shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
  env:
    CALYPTIA_CLI_VERSION: latest
    CALYPTIA_CLOUD_URL: https://cloud-api-dev.calyptia.com/
    CALYPTIA_CLOUD_TOKEN: ***
    GITHUB_TOKEN: ***
mv: cannot stat '//tmp/fluent-bit/*.zip': No such file or directory
Error: Process completed with exit code 1.
```