### PR TITLE
[FIX] update package download to work with new test step

### DIFF
--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -99,6 +99,7 @@ jobs:
 
       - name: Download Fluent-Bit Binary from Artefact
         if: ${{ inputs.calyptia-package-artefact }}
+        id: download
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.calyptia-package-artefact }}
@@ -107,11 +108,11 @@ jobs:
       - name: Transform Download Path to MSYS2
         if: ${{ inputs.calyptia-package-artefact }}
         # transform download-path into msys2 equivalent
-        run: |
-          DP="/tmp/fluent-bit"
-          DP=$(echo $DP | sed 's/\([A-Za-z]\)\:/\l\1/' | sed 's/\\/\//g')
-          mv "/${DP}/"*.zip /tmp/calyptia-fluent-bit.zip
         shell: bash
+        run: |
+          DP="${{ steps.download.outputs.download-path }}"
+          DP="/"$(echo $DP | sed 's/\([A-Za-z]\)\:/\l\1/' | sed 's/\\/\//g')
+          mv "${DP}/"*.zip /tmp/calyptia-fluent-bit.zip
 
       - name: Unzip Calyptia Package
         if: ${{ inputs.calyptia-package-artefact }}

--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -119,7 +119,8 @@ jobs:
         run: |
           unzip /tmp/calyptia-fluent-bit.zip -d /tmp
           mv /tmp/calyptia-fluent-bit-* /tmp/calyptia-fluent-bit
-          echo "bin=/tmp/calyptia-fluent-bit/bin/calyptia-fluent-bit" >> "${GITHUB_OUTPUT}"
+          echo "/tmp/calyptia-fluent-bit/bin/" \
+            >> "${GITHUB_PATH}"
         shell: bash
 
       - name: Grab uploaded Fluent Bit binary


### PR DESCRIPTION
This PR adds a missing slash to the zip path as well as adding the calyptia-fluent-bit binary to the path.

A successful run of the fleet workrflow can be seen here: https://github.com/calyptia/calyptia-fluent-bit/actions/runs/7463159099/job/20309659213

The run fails but in the actual end to end fleet tests which still need work.
